### PR TITLE
Fix implicitly tagged sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rasn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bitvec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rasn"
-version = "0.2.1"
+version = "0.2.2"
 categories = ["encoding", "no-std", "parser-implementations"]
 authors = ["Erin Power <xampprocky@gmail.com>"]
 edition = "2018"

--- a/src/ber.rs
+++ b/src/ber.rs
@@ -201,4 +201,23 @@ mod tests {
         assert_eq!(data, &*crate::ber::encode(&value).unwrap());
         assert_eq!(value, crate::ber::decode::<Explicit<C0, _>>(data).unwrap());
     }
+
+    #[test]
+    fn implicit_tagged_constructed() {
+        use crate::{tag::Class, types::Implicit, AsnType, Tag};
+        #[derive(Debug, PartialEq)]
+        struct C0;
+        impl AsnType for C0 {
+            const TAG: Tag = Tag::new(Class::Context, 0);
+        }
+
+        let value = <Implicit<C0, _>>::new(vec![1, 2]);
+        let data = &[0xA0, 6, 2, 1, 1, 2, 1, 2][..];
+
+        assert_eq!(data, &*crate::ber::encode(&value).unwrap());
+        assert_eq!(
+            value,
+            crate::ber::decode::<Implicit<C0, Vec<i32>>>(data).unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Addresses #7, adds an `encode_constructed` function to replace `encode_value` when called to encode sequences or sets.
Added test case to confirm this behavior.

All other tests pass.