### PR TITLE
Small improvements to error messages, and clean up newly-dead tag constant defs

### DIFF
--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -175,6 +175,10 @@ pub fn derive_enum_impl(
             }
         });
 
+        let match_fail_error = format!(
+            "Decoding field of type `{}`: Invalid `CHOICE` discriminant.",
+            name.to_string(),
+        );
         Some(quote! {
             fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> Result<Self, D::Error> {
                 #(
@@ -183,7 +187,7 @@ pub fn derive_enum_impl(
 
                 #(#variants)*
 
-                Err(#crate_root::de::Error::custom("Invalid `CHOICE` discriminant."))
+                Err(#crate_root::de::Error::custom(#match_fail_error))
             }
         })
     } else {

--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -123,18 +123,6 @@ pub fn derive_enum_impl(
     };
 
     let decode = if config.choice {
-        let tags = container
-            .variants
-            .iter()
-            .enumerate()
-            .map(|(i, _)| quote::format_ident!("TAG_{}", i));
-
-        let tag_consts = container
-            .variants
-            .iter()
-            .enumerate()
-            .map(|(i, v)| VariantConfig::new(&v, config).tag(i));
-
         let variants = container.variants.iter().enumerate().map(|(i, v)| {
             let variant_config = VariantConfig::new(&v, config);
             let variant_tag = variant_config.tag(i);
@@ -181,12 +169,7 @@ pub fn derive_enum_impl(
         );
         Some(quote! {
             fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> Result<Self, D::Error> {
-                #(
-                    const #tags: #crate_root::Tag = #tag_consts;
-                )*
-
                 #(#variants)*
-
                 Err(#crate_root::de::Error::custom(#match_fail_error))
             }
         })

--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -111,7 +111,11 @@ pub fn derive_enum_impl(
 
         }
     } else {
-        let error = crate::CHOICE_ERROR_MESSAGE;
+        let error = format!(
+            "Decoding field of type `{}`: {}",
+            name.to_string(),
+            crate::CHOICE_ERROR_MESSAGE
+        );
 
         quote! {
             Err(#crate_root::de::Error::custom(#error))

--- a/macros/src/encode.rs
+++ b/macros/src/encode.rs
@@ -92,7 +92,11 @@ pub fn derive_enum_impl(
             encoder.encode_enumerated(tag, *self as isize).map(drop)
         }
     } else {
-        let error = crate::CHOICE_ERROR_MESSAGE;
+        let error = format!(
+            "Encoding field of type `{}`: {}",
+            name.to_string(),
+            crate::CHOICE_ERROR_MESSAGE
+        );
         quote! {
             Err::<(), _>(#crate_root::enc::Error::custom(#error))
         }


### PR DESCRIPTION
Some small changes to add type information to the error messages about CHOICE enums, to help narrow down the search for issues with deeply-nested data structures.

Also, I noticed the `TAG_n` constant definitions emitted in `derive_enum_impl` are no longer referenced since the match block has been completely eliminated, so I removed them for a small cleanup.