### PR TITLE
Redo: Changed `slice_range(foo, _, foo.len())` to `slice_from(foo, _)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bitvec = { version = "0.22.3", default-features = false, features = ["alloc"] }
 rasn-derive = { version = "0.3.0", path = "macros", optional = true }
 chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 static_assertions = "1.1.0"
-konst = "0.2.5"
+konst = {version = "0.2.5", default-features = false}
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/types/tag.rs
+++ b/src/types/tag.rs
@@ -142,7 +142,7 @@ impl TagTree {
                     while inner_index < inner_tags.len() {
                         if Self::tree_contains(
                             &inner_tags[inner_index],
-                            konst::slice::slice_range(&nodes, index + 1, nodes.len()),
+                            konst::slice::slice_from(&nodes, index + 1),
                         ) {
                             return false;
                         }
@@ -160,7 +160,7 @@ impl TagTree {
 
                     if Self::tag_contains(
                         tag,
-                        konst::slice::slice_range(&nodes, index + 1, nodes.len()),
+                        konst::slice::slice_from(&nodes, index + 1),
                     ) {
                         return false;
                     }


### PR DESCRIPTION
Disabled default feature of konst dependency, since no crate features are used.