### PR TITLE
Add new example for RFC 7030 standard

### DIFF
--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -588,6 +588,8 @@ mod tests {
 
     #[test]
     fn decoding_oid() {
+        use crate::Decoder;
+
         let mut decoder =
             super::Decoder::new(&[0x06, 0x03, 0x88, 0x37, 0x01], DecoderOptions::der());
         let oid = decoder.decode_object_identifier(Tag::OBJECT_IDENTIFIER);

--- a/src/types/oid.rs
+++ b/src/types/oid.rs
@@ -5,7 +5,7 @@ pub(crate) const MAX_OID_FIRST_OCTET: u32 = 2;
 pub(crate) const MAX_OID_SECOND_OCTET: u32 = 39;
 
 const fn is_valid_oid(slice: &[u32]) -> bool {
-    slice.len() >= 2 && slice[0] <= MAX_OID_FIRST_OCTET && slice[1] <= MAX_OID_SECOND_OCTET
+    slice.len() >= 2 && slice[0] <= MAX_OID_FIRST_OCTET
 }
 
 /// A temporary workaround for [`Oid`] not currently being `const` compatible.

--- a/src/types/open.rs
+++ b/src/types/open.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{Decode, Encode};
 
 /// An "open" type representing any valid ASN.1 type.
-#[derive(AsnType, Debug, Clone, PartialEq, Decode, Encode)]
+#[derive(AsnType, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Decode, Encode)]
 #[rasn(crate_root = "crate")]
 #[rasn(choice)]
 pub enum Open {
@@ -18,5 +18,6 @@ pub enum Open {
     UniversalString(UniversalString),
     UtcTime(UtcTime),
     VisibleString(VisibleString),
+    ObjectIdentifier(ObjectIdentifier),
     InstanceOf(alloc::boxed::Box<InstanceOf<Open>>),
 }

--- a/src/types/open.rs
+++ b/src/types/open.rs
@@ -13,11 +13,11 @@ pub enum Open {
     Ia5String(Ia5String),
     Integer(Integer),
     Null,
+    ObjectIdentifier(ObjectIdentifier),
     OctetString(OctetString),
     PrintableString(PrintableString),
     UniversalString(UniversalString),
     UtcTime(UtcTime),
     VisibleString(VisibleString),
-    ObjectIdentifier(ObjectIdentifier),
     InstanceOf(alloc::boxed::Box<InstanceOf<Open>>),
 }

--- a/standards/rfc7030/Cargo.toml
+++ b/standards/rfc7030/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rasn-rfc7030"
+version = "0.1.0"
+edition = "2018"
+description = "Data types for handling types in RFC7030."
+license = "Apache-2.0/MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rasn = { path = "../..", version = "0.3" }
+
+[dev-dependencies]
+base64 = "0.13"

--- a/standards/rfc7030/src/lib.rs
+++ b/standards/rfc7030/src/lib.rs
@@ -1,0 +1,206 @@
+/*
+From RFC7030 (https://datatracker.ietf.org/doc/html/rfc7030):
+CsrAttrs ::= SEQUENCE SIZE (0..MAX) OF AttrOrOID
+AttrOrOID ::= CHOICE { oid OBJECT IDENTIFIER, attribute Attribute }
+Attribute ::= SEQUENCE {
+        type  OBJECT IDENTIFIER,
+        values SET SIZE(0..MAX) OF ANY }
+*/
+
+#[cfg(test)]
+type CsrAttrs = Vec<AttrOrOid>;
+
+#[derive(rasn::AsnType, rasn::Decode, rasn::Encode, Debug, PartialEq, Clone)]
+#[rasn(choice)]
+enum AttrOrOid {
+    OID(rasn::types::ObjectIdentifier),
+    ATTRIBUTE(Attribute),
+}
+
+#[derive(rasn::AsnType, rasn::Decode, rasn::Encode, Debug, PartialEq, Clone)]
+struct Attribute {
+    r#type: rasn::types::ObjectIdentifier,
+    values: rasn::types::SetOf<rasn::types::Open>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn csr_attributes_encode() {
+        let data = vec![
+            // ecdsaWithSHA256 (ANSI X9.62 ECDSA algorithm with SHA256)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 10045, 4, 3, 2,
+            ])),
+            // commonName (X.520 DN component)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                2, 5, 4, 3,
+            ])),
+            // emailAddress (PKCS #9. Deprecated, use an altName extension instead)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 113549, 1, 9, 1,
+            ])),
+            // challengePassword (PKCS #9)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 113549, 1, 9, 7,
+            ])),
+            // ocsp (PKIX)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 3, 6, 1, 5, 5, 7, 48, 1,
+            ])),
+            // requestClientInfo (Microsoft attribute)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 3, 6, 1, 4, 1, 311, 21, 20,
+            ])),
+            // 1.2.840.113549.1.1.5 (sha1WithRsaEncryption)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 113549, 1, 1, 5,
+            ])),
+            AttrOrOid::ATTRIBUTE(Attribute {
+                r#type: rasn::types::ObjectIdentifier::new_unchecked(vec![
+                    1, 3, 6, 1, 5, 5, 7, 48, 1,
+                ]),
+                values: (|| {
+                    let mut b = BTreeSet::new();
+                    b.insert(rasn::types::Open::PrintableString(
+                        rasn::types::PrintableString::new("And me second".to_string()),
+                    ));
+                    b.insert(rasn::types::Open::Bool(false));
+                    b.insert(rasn::types::Open::Null);
+                    b.insert(rasn::types::Open::VisibleString(
+                        rasn::types::VisibleString::new("Me first!".to_string()),
+                    ));
+                    b
+                })(),
+            }),
+        ];
+
+        let bin = rasn::der::encode(&data).unwrap();
+        assert_eq!(
+            bin,
+            [
+                48, 114, 6, 8, 42, 134, 72, 206, 61, 4, 3, 2, 6, 3, 85, 4, 3, 6, 9, 42, 134, 72,
+                134, 247, 13, 1, 9, 1, 6, 9, 42, 134, 72, 134, 247, 13, 1, 9, 7, 6, 8, 43, 6, 1, 5,
+                5, 7, 48, 1, 6, 9, 43, 6, 1, 4, 1, 130, 55, 21, 20, 6, 9, 42, 134, 72, 134, 247,
+                13, 1, 1, 5, 48, 43, 6, 8, 43, 6, 1, 5, 5, 7, 48, 1, 49, 31, 1, 1, 0, 5, 0, 19, 13,
+                65, 110, 100, 32, 109, 101, 32, 115, 101, 99, 111, 110, 100, 26, 9, 77, 101, 32,
+                102, 105, 114, 115, 116, 33
+            ]
+        );
+    }
+
+    #[test]
+    fn csr_attributes_decode_1() {
+        let data = vec![
+            // challengePassword (PKCS #9)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 113549, 1, 9, 7,
+            ])),
+            // ecPublicKey (ANSI X9.62 public key type)
+            AttrOrOid::ATTRIBUTE(Attribute {
+                r#type: rasn::types::ObjectIdentifier::new_unchecked(vec![1, 2, 840, 10045, 2, 1]),
+                values: (|| {
+                    let mut b = BTreeSet::new();
+                    b.insert(rasn::types::Open::ObjectIdentifier(
+                        // secp384r1 (SECG (Certicom) named elliptic curve)
+                        rasn::types::ObjectIdentifier::new_unchecked(vec![1, 3, 132, 0, 34]),
+                    ));
+                    b
+                })(),
+            }),
+            AttrOrOid::ATTRIBUTE(Attribute {
+                // extensionRequest (PKCS #9 via CRMF)
+                r#type: rasn::types::ObjectIdentifier::new_unchecked(vec![
+                    1, 2, 840, 113549, 1, 9, 14,
+                ]),
+                values: (|| {
+                    let mut b = BTreeSet::new();
+                    b.insert(rasn::types::Open::ObjectIdentifier(
+                        rasn::types::ObjectIdentifier::new_unchecked(vec![1, 3, 6, 1, 1, 1, 1, 22]),
+                    ));
+                    b
+                })(),
+            }),
+            // ecdsaWithSHA384 (ANSI X9.62 ECDSA algorithm with SHA384)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 10045, 4, 3, 3,
+            ])),
+        ];
+
+        let data_bin = rasn::der::encode(&data).unwrap();
+        let txt = "MEEGCSqGSIb3DQEJBzASBgcqhkjOPQIBMQcGBSuBBAAiMBYGCSqGSIb3DQEJDjEJBgcrBgEBAQEWBggqhkjOPQQDAw==";
+        let bin = base64::decode(&txt).unwrap();
+        assert_eq!(data_bin, bin);
+        let decoded_data = rasn::der::decode::<CsrAttrs>(&bin);
+        assert!(decoded_data.is_ok());
+        let decoded_data = decoded_data.unwrap();
+        assert_eq!(decoded_data, data);
+    }
+
+    #[test]
+    fn csr_attributes_decode_2() {
+        let data = vec![
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 3, 6, 1, 1, 1, 1, 22,
+            ])),
+            // ecPublicKey (ANSI X9.62 public key type)
+            AttrOrOid::ATTRIBUTE(Attribute {
+                r#type: rasn::types::ObjectIdentifier::new_unchecked(vec![2, 999, 1]),
+                values: (|| {
+                    let mut b = BTreeSet::new();
+                    b.insert(rasn::types::Open::PrintableString(
+                        rasn::types::PrintableString::new("Parse SET as 2.999.1 data".to_string()),
+                    ));
+                    b
+                })(),
+            }),
+            // challengePassword (PKCS #9)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 2, 840, 113549, 1, 9, 7,
+            ])),
+            AttrOrOid::ATTRIBUTE(Attribute {
+                r#type: rasn::types::ObjectIdentifier::new_unchecked(vec![2, 999, 2]),
+                values: (|| {
+                    let mut b = BTreeSet::new();
+                    b.insert(rasn::types::Open::ObjectIdentifier(
+                        rasn::types::ObjectIdentifier::new_unchecked(vec![2, 999, 3]),
+                    ));
+                    b.insert(rasn::types::Open::ObjectIdentifier(
+                        rasn::types::ObjectIdentifier::new_unchecked(vec![2, 999, 4]),
+                    ));
+                    b.insert(rasn::types::Open::PrintableString(
+                        rasn::types::PrintableString::new("Parse SET as 2.999.2 data".to_string()),
+                    ));
+                    b
+                })(),
+            }),
+            // brainpoolP384r1 (ECC Brainpool Standard Curves and Curve Generation)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                1, 3, 36, 3, 3, 2, 8, 1, 1, 11,
+            ])),
+            // sha-384 (NIST Algorithm)
+            AttrOrOid::OID(rasn::types::ObjectIdentifier::new_unchecked(vec![
+                2, 16, 840, 1, 101, 3, 4, 2, 2,
+            ])),
+        ];
+
+        let data_bin = rasn::der::encode(&data).unwrap();
+        println!("Encoded data (raw): {:x?}", &data_bin);
+        let data_b64_bin = base64::encode(&data_bin);
+        println!("Encoded data (b64): {}", &data_b64_bin);
+
+        let txt = "MHwGBysGAQEBARYwIgYDiDcBMRsTGVBhcnNlIFNFVCBhcyAyLjk5OS4xIGRhdGEGCSqGSIb3DQEJBzAsBgOINwIxJQYDiDcDBgOINwQTGVBhcnNlIFNFVCBhcyAyLjk5OS4yIGRhdGEGCSskAwMCCAEBCwYJYIZIAWUDBAIC";
+        let bin = base64::decode(&txt).unwrap();
+        println!("Encoded data (raw): {:x?}", &bin);
+        assert_eq!(data_bin, bin);
+        let decoded_data = rasn::der::decode::<CsrAttrs>(&bin);
+        println!("Result from decode {:?}", &decoded_data);
+        assert!(decoded_data.is_ok());
+        let decoded_data = decoded_data.unwrap();
+        assert_eq!(decoded_data, data);
+    }
+}

--- a/standards/rfc7030/tests/fuzz.rs
+++ b/standards/rfc7030/tests/fuzz.rs
@@ -1,0 +1,2 @@
+#[test]
+fn splice() {}


### PR DESCRIPTION
- add new item to standards: RFC7030 and reading of CSR attributes
- add missing `Eq`, `PartialOrd` and `Ord` for `Open` type; additionally add `ObjectIdentifier` to the enum
- allow to encode OIDs where second number is bigger than 39, e.g. 2.999.x is common OID in many examples
- update tests where appropriate
- somehow `cargo fmt` formatted code differently (newer version?)