### PR TITLE
Convert `Result` in macros to `core::result::Result`

### DIFF
--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -138,7 +138,7 @@ pub fn derive_struct_impl(
 
     quote! {
         impl #impl_generics #crate_root::Decode for #name #ty_generics #where_clause {
-            fn decode_with_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> Result<Self, D::Error> {
+            fn decode_with_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> core::result::Result<Self, D::Error> {
                 #decode_impl
             }
         }
@@ -178,7 +178,7 @@ pub fn map_from_inner_type(
         struct #inner_name #generics #fields #semi
 
         impl #impl_generics #crate_root::Decode for #inner_name #ty_generics #where_clause {
-            fn decode_with_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> Result<Self, D::Error> {
+            fn decode_with_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> core::result::Result<Self, D::Error> {
                 decoder.decode_sequence(tag, |decoder| {
                     Ok::<_, D::Error>(#inner_name { #(#decode_fields),* })
                 })

--- a/macros/src/encode.rs
+++ b/macros/src/encode.rs
@@ -71,7 +71,7 @@ pub fn derive_struct_impl(
     let vars = fields_as_vars(&container.fields);
     quote! {
         impl #impl_generics  #crate_root::Encode for #name #ty_generics #where_clause {
-            fn encode_with_tag<EN: #crate_root::Encoder>(&self, encoder: &mut EN, tag: #crate_root::Tag) -> Result<(), EN::Error> {
+            fn encode_with_tag<EN: #crate_root::Encoder>(&self, encoder: &mut EN, tag: #crate_root::Tag) -> core::result::Result<(), EN::Error> {
                 #(#vars)*
 
                 #encode_impl
@@ -147,7 +147,7 @@ pub fn map_to_inner_type(
             }
 
         impl #impl_generics  #crate_root::Encode for #inner_name #ty_generics #where_clause {
-            fn encode_with_tag<EN: #crate_root::Encoder>(&self, encoder: &mut EN, tag: #crate_root::Tag) -> Result<(), EN::Error> {
+            fn encode_with_tag<EN: #crate_root::Encoder>(&self, encoder: &mut EN, tag: #crate_root::Tag) -> core::result::Result<(), EN::Error> {
                 #(#vars)*
 
                 #encode_impl

--- a/macros/src/enum.rs
+++ b/macros/src/enum.rs
@@ -159,7 +159,7 @@ impl Enum {
             });
 
             quote! {
-                fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> Result<Self, D::Error> {
+                fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> core::result::Result<Self, D::Error> {
                     #inner_type
                     #asntype
                     #decode_impl
@@ -172,7 +172,7 @@ impl Enum {
             }
         } else {
             quote! {
-                fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> Result<Self, D::Error> {
+                fn decode<D: #crate_root::Decoder>(decoder: &mut D) -> core::result::Result<Self, D::Error> {
                     #decode_op
                 }
             }
@@ -183,7 +183,7 @@ impl Enum {
         quote! {
             #[automatically_derived]
             impl #impl_generics #crate_root::Decode for #name #ty_generics #where_clause {
-                fn decode_with_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> Result<Self, D::Error> {
+                fn decode_with_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> core::result::Result<Self, D::Error> {
                     #decode_with_tag
                 }
 
@@ -205,7 +205,7 @@ impl Enum {
         };
 
         quote! {
-            fn encode_with_tag<EN: #crate_root::Encoder>(&self, encoder: &mut EN, tag: #crate_root::Tag) -> Result<(), EN::Error> {
+            fn encode_with_tag<EN: #crate_root::Encoder>(&self, encoder: &mut EN, tag: #crate_root::Tag) -> core::result::Result<(), EN::Error> {
                 #operation
             }
         }
@@ -369,7 +369,7 @@ impl Enum {
         };
 
         quote! {
-            fn encode<E: #crate_root::Encoder>(&self, encoder: &mut E) -> Result<(), E::Error> {
+            fn encode<E: #crate_root::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), E::Error> {
                 #encode_impl.map(drop)
             }
         }


### PR DESCRIPTION
The idea here is when using the #[derive()] macros, we don't interfere with libraries that have aliased `Result` to `Result<T, MyError>`.