### PR TITLE
AttributeCertificateValidityPeriod public fields

### DIFF
--- a/standards/pkix/src/attribute_certificate.rs
+++ b/standards/pkix/src/attribute_certificate.rs
@@ -112,8 +112,8 @@ pub struct IssuerSerial {
 
 #[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttributeCertificateValidityPeriod {
-    not_before: GeneralizedTime,
-    not_after: GeneralizedTime,
+    pub not_before: GeneralizedTime,
+    pub not_after: GeneralizedTime,
 }
 
 #[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
Just like the Validity structure:
```rust
/// The validity period of the certificate.
#[derive(AsnType, Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
pub struct Validity {
    pub not_before: Time,
    pub not_after: Time,
}
```

I made the AttributeCertificateValidityPeriod fields also pub
```rust
#[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
pub struct AttributeCertificateValidityPeriod {
    pub not_before: GeneralizedTime,
    pub not_after: GeneralizedTime,
}
```