### PR TITLE
wip: very very basic compiler implementation

### DIFF
--- a/compiler/src/codegen/constant.rs
+++ b/compiler/src/codegen/constant.rs
@@ -24,11 +24,13 @@ impl Constant {
     pub fn generate(self, backend: &mut Rust) -> Fallible<String> {
         use heck::ShoutySnakeCase;
 
+        let (ty, _) = backend.generate_type(&self.ty, None)?;
+
         Ok(format!(
             "{vis}const {name}: {ty} = {value};",
             vis = self.visibility,
             name = self.name.to_shouty_snake_case(),
-            ty = backend.generate_type(&self.ty)?,
+            ty = ty,
             value = backend.generate_value(&self.value)?,
         ))
     }

--- a/compiler/src/codegen/constant_enum.rs
+++ b/compiler/src/codegen/constant_enum.rs
@@ -1,0 +1,89 @@
+use failure::Fallible;
+use heck::CamelCase;
+use itertools::Itertools;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+
+use super::imports::Visibility;
+
+#[derive(Clone, Debug, Eq)]
+pub struct Triple {
+    pub key: String,
+    pub value_type: String,
+    pub value: String,
+}
+
+impl Triple {
+    pub fn new(key: String, value_type: String, value: String) -> Self {
+        Self {
+            key,
+            value_type,
+            value,
+        }
+    }
+}
+
+impl PartialEq for Triple {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl Hash for Triple {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.key.as_bytes());
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
+pub struct ConstantEnum {
+    visibility: Visibility,
+    name: String,
+    variants: HashSet<Triple>,
+}
+
+impl PartialEq for ConstantEnum {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Hash for ConstantEnum {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.name.as_bytes());
+    }
+}
+
+impl ConstantEnum {
+    pub fn new(visibility: Visibility, name: String, variants: HashSet<Triple>) -> Self {
+        Self {
+            visibility,
+            name,
+            variants,
+        }
+    }
+
+    pub fn generate(self) -> String {
+        format!(
+            r#"
+#[non_exhaustive]
+{vis}struct {name};
+impl {name} {{
+{variants}
+}}"#,
+            vis = self.visibility,
+            name = self.name.to_camel_case(),
+            variants = self
+                .variants
+                .iter()
+                .map(|triple| format!(
+                    "\t{}{}: {} = {};",
+                    self.visibility,
+                    triple.key.to_camel_case(),
+                    triple.value_type.to_camel_case(),
+                    triple.value
+                ))
+                .join("\n"),
+        )
+    }
+}

--- a/compiler/src/codegen/imports.rs
+++ b/compiler/src/codegen/imports.rs
@@ -43,3 +43,9 @@ impl fmt::Display for Visibility {
         visibility.fmt(f)
     }
 }
+
+impl Default for Visibility {
+    fn default() -> Self {
+        Visibility::Private
+    }
+}

--- a/compiler/src/codegen/structs.rs
+++ b/compiler/src/codegen/structs.rs
@@ -68,7 +68,13 @@ pub struct Field {
 impl fmt::Display for Field {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.attributes.is_empty() {
-            itertools::join(self.attributes.iter().map(ToString::to_string), "\n").fmt(f)?;
+            itertools::join(
+                self.attributes
+                    .iter()
+                    .map(|x| format!("\t{}", x.to_string())),
+                "\n",
+            )
+            .fmt(f)?;
             writeln!(f)?;
         }
 

--- a/compiler/src/codegen/structs.rs
+++ b/compiler/src/codegen/structs.rs
@@ -1,25 +1,40 @@
+use crate::codegen::imports::Visibility;
+use crate::parser::{Prefix, TagKind};
 use std::fmt;
 
 pub struct Struct {
+    visibility: Visibility,
     name: String,
     fields: Vec<Field>,
     attributes: Vec<Attribute>,
 }
 
 impl Struct {
-    pub fn new<I: Into<String>>(name: I) -> Self {
+    pub fn new<I: Into<String>>(visibility: Visibility, name: I) -> Self {
         Self {
+            visibility,
             name: name.into(),
             fields: Vec::new(),
             attributes: vec![Attribute::Derive(vec![
-                Derive::Serialize,
-                Derive::Deserialize,
+                Derive::AsnType,
+                Derive::Encode,
+                Derive::Decode,
+                Derive::PartialEq,
+                Derive::PartialOrd,
+                Derive::Eq,
+                Derive::Ord,
+                Derive::Debug,
             ])],
         }
     }
 
     pub fn add_field(&mut self, field: Field) {
         self.fields.push(field);
+    }
+
+    pub fn add_rasn_attributes(mut self, attributes: Vec<Rasn>) -> Self {
+        self.attributes.push(Attribute::Rasn(attributes));
+        self
     }
 }
 
@@ -30,7 +45,7 @@ impl fmt::Display for Struct {
             writeln!(f)?;
         }
 
-        writeln!(f, "struct {} {{", self.name)?;
+        writeln!(f, "{}struct {} {{", self.visibility, self.name)?;
 
         if !self.fields.is_empty() {
             itertools::join(self.fields.iter().map(ToString::to_string), "\n").fmt(f)?;
@@ -42,6 +57,7 @@ impl fmt::Display for Struct {
 }
 
 pub struct Field {
+    visibility: Visibility,
     attributes: Vec<Attribute>,
     name: String,
     optional: bool,
@@ -62,16 +78,18 @@ impl fmt::Display for Field {
             self.ty.clone()
         };
 
-        write!(f, "{}: {},", self.name, ty)
+        write!(f, "\t{}{}: {},", self.visibility, self.name, ty)
     }
 }
 
 #[derive(Default)]
 pub struct FieldBuilder {
+    visibility: Visibility,
     name: String,
     ty: String,
     optional: bool,
     default_value: Option<String>,
+    attributes: Vec<Attribute>,
 }
 
 impl FieldBuilder {
@@ -80,10 +98,16 @@ impl FieldBuilder {
         let ty = ty.into();
 
         Self {
+            visibility: Visibility::Private,
             name,
             ty,
             ..Self::default()
         }
+    }
+
+    pub fn visibility(mut self, visibility: Visibility) -> Self {
+        self.visibility = visibility;
+        self
     }
 
     pub fn optional(mut self, optional: bool) -> Self {
@@ -96,15 +120,20 @@ impl FieldBuilder {
         self
     }
 
-    pub fn build(self) -> Field {
-        let mut attributes = Vec::new();
+    pub fn add_rasn_attribute(mut self, attributes: Vec<Rasn>) -> Self {
+        self.attributes.push(Attribute::Rasn(attributes));
+        self
+    }
 
+    pub fn build(mut self) -> Field {
         if let Some(default_value) = self.default_value {
-            attributes.push(Attribute::Serde(Serde::Default(default_value)));
+            self.attributes
+                .push(Attribute::Serde(Serde::Default(default_value)));
         }
 
         Field {
-            attributes,
+            visibility: self.visibility,
+            attributes: self.attributes,
             name: self.name,
             optional: self.optional,
             ty: self.ty,
@@ -115,6 +144,7 @@ impl FieldBuilder {
 pub enum Attribute {
     Serde(Serde),
     Derive(Vec<Derive>),
+    Rasn(Vec<Rasn>),
 }
 
 impl fmt::Display for Attribute {
@@ -125,6 +155,10 @@ impl fmt::Display for Attribute {
             },
             Attribute::Derive(defaults) => format!(
                 "#[derive({})]",
+                itertools::join(defaults.iter().map(ToString::to_string), ", ")
+            ),
+            Attribute::Rasn(defaults) => format!(
+                "#[rasn({})]",
                 itertools::join(defaults.iter().map(ToString::to_string), ", ")
             ),
         };
@@ -138,17 +172,70 @@ pub enum Serde {
 }
 
 pub enum Derive {
-    Serialize,
-    Deserialize,
+    AsnType,
+    Encode,
+    Decode,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    Debug,
 }
 
 impl fmt::Display for Derive {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let derive = match self {
-            Derive::Serialize => "Serialize",
-            Derive::Deserialize => "Deserialize",
+            Derive::AsnType => "AsnType",
+            Derive::Encode => "Encode",
+            Derive::Decode => "Decode",
+            Derive::PartialEq => "PartialEq",
+            Derive::PartialOrd => "PartialOrd",
+            Derive::Eq => "Eq",
+            Derive::Ord => "Ord",
+            Derive::Debug => "Debug",
         };
 
         derive.fmt(f)
+    }
+}
+
+pub enum Rasn {
+    Type(&'static str),
+    Prefix(Prefix),
+}
+
+impl fmt::Display for Rasn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let rasn = match self {
+            Rasn::Type(type_name) => type_name.to_string(),
+            Rasn::Prefix(prefix) => match prefix.kind {
+                TagKind::Explicit => format!(
+                    "tag(explicit({class}{number}))",
+                    class = prefix
+                        .class
+                        .map(|x| x.to_string().to_lowercase() + ", ")
+                        .unwrap_or(String::from("")),
+                    number = prefix.number
+                ),
+                TagKind::Implicit => format!(
+                    "tag(implicit({class}{number}))",
+                    class = prefix
+                        .class
+                        .map(|x| x.to_string().to_lowercase() + ", ")
+                        .unwrap_or(String::from("")),
+                    number = prefix.number
+                ),
+                _ => format!(
+                    "tag({class}{number})",
+                    class = prefix
+                        .class
+                        .map(|x| x.to_string().to_lowercase() + ", ")
+                        .unwrap_or(String::from("")),
+                    number = prefix.number
+                ),
+            },
+        };
+
+        rasn.fmt(f)
     }
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -41,8 +41,7 @@ impl NotationCompiler {
 
         let mut output = Vec::new();
 
-        CodeGenerator::<Vec<u8>, Rust>::new(fixed_tree, &mut output)
-            .generate()?;
+        CodeGenerator::<Vec<u8>, Rust>::new(fixed_tree, &mut output).generate()?;
 
         Ok(String::from_utf8(output).unwrap())
     }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -994,7 +994,7 @@ impl<'a> Parser<'a> {
             component_list.extension = Some(Extension {
                 exception,
                 additions,
-                marker
+                marker,
             });
         }
 

--- a/compiler/src/parser/types/prefix.rs
+++ b/compiler/src/parser/types/prefix.rs
@@ -9,7 +9,12 @@ pub struct Prefix {
 }
 
 impl Prefix {
-    pub fn new(encoding: Option<String>, kind: TagKind, class: Option<Class>, number: Number) -> Self {
+    pub fn new(
+        encoding: Option<String>,
+        kind: TagKind,
+        class: Option<Class>,
+        number: Number,
+    ) -> Self {
         Self {
             encoding,
             class,


### PR DESCRIPTION
It can convert this `asn1` schema:
```asn1
Simple DEFINITIONS ::=
BEGIN
  SimpleSequence ::= SEQUENCE {
    someInt INTEGER,
    someBytes OCTET STRING
  }

  MoreComplexSequence ::= SEQUENCE {
    someOptionalInt INTEGER OPTIONAL,
    someIntEnum INTEGER {value1(123), value2(456)},
    someOptionalBytes OCTET STRING OPTIONAL,
    someOptionalReference SimpleSequence OPTIONAL,
    someOptionalReferenceWithContextNumber [2] SimpleSequence OPTIONAL,
    someAnonymousSequence SEQUENCE {
        simpleInt INTEGER
    }
  }

  MainSequence ::= [APPLICATION 1] EXPLICIT SEQUENCE {
    simpleSequence SimpleSequence,
    moreComplexSequence MoreComplexSequence
  }
END
```

To this `Rust` code:
```rust
use rasn::types::OctetString;
use rasn::types::Integer;
use rasn::Encode;
use rasn::Decode;
use rasn::AsnType;
#[non_exhaustive]
pub struct SomeIntEnum;
impl SomeIntEnum {
	pub Value2: Integer = 456;
	pub Value1: Integer = 123;
}

#[derive(AsnType, Encode, Decode, PartialEq, PartialOrd, Eq, Ord, Debug)]
#[rasn(tag(explicit(application, 1)))]
pub struct MainSequence {
	pub simple_sequence: SimpleSequence,
	pub more_complex_sequence: MoreComplexSequence,
}

#[derive(AsnType, Encode, Decode, PartialEq, PartialOrd, Eq, Ord, Debug)]
pub struct SomeAnonymousSequence {
	pub simple_int: Integer,
}

#[derive(AsnType, Encode, Decode, PartialEq, PartialOrd, Eq, Ord, Debug)]
pub struct MoreComplexSequence {
	pub some_optional_int: Option<Integer>,
	pub some_int_enum: Integer,
	pub some_optional_bytes: Option<OctetString>,
	pub some_optional_reference: Option<SimpleSequence>,
	#[rasn(tag(2))]
	pub some_optional_reference_with_context_number: Option<SimpleSequence>,
	pub some_anonymous_sequence: SomeAnonymousSequence,
}

#[derive(AsnType, Encode, Decode, PartialEq, PartialOrd, Eq, Ord, Debug)]
pub struct SimpleSequence {
	pub some_int: Integer,
	pub some_bytes: OctetString,
}
```