### PR TITLE
Allow buffer reuse in `Encoder`

### DIFF
--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -57,6 +57,15 @@ impl Encoder {
         }
     }
 
+    /// Creates a new instance from the given `config` and a user-supplied
+    /// `Vec<u8>` buffer. This allows reuse of an existing buffer instead of
+    /// allocating a new encoding buffer each time an [`Encoder`] is created.
+    /// The buffer will be cleared before use.
+    pub fn new_with_buffer(config: EncoderOptions, mut buffer: Vec<u8>) -> Self {
+        buffer.clear();
+        Self { output: buffer, config, is_set_encoding: false, set_buffer: <_>::default() }
+    }
+
     /// Consumes the encoder and returns the output of the encoding.
     pub fn output(self) -> Vec<u8> {
         if self.is_set_encoding {


### PR DESCRIPTION
Fixes #72 

I think this should be sufficient for my use case, however I did have a question. I originally had a `new_set_with_buffer` but as `self.output()` doesn't actually use the `self.output` for the final encoding when `is_set_encoding: true` and is `mem::take(&mut self.output)`'d elsewhere, I felt like it would be pretty useless since the whole point is to allow reusing the buffer space for the final encoding, but this does kind of expose this implementation detail and could cause some confusion since there's a missing function, not entirely sure what a good solution is for this.

Let me know if there's anything else you'd like adjusted.