### PR TITLE
fix: remove duplicates in PrintableString char set

### DIFF
--- a/src/types/strings/printable.rs
+++ b/src/types/strings/printable.rs
@@ -6,9 +6,9 @@ pub struct PrintableString(Vec<u8>);
 
 impl StaticPermittedAlphabet for PrintableString {
     const CHARACTER_SET: &'static [u32] = &bytes_to_chars([
-        b'A', b'B', b'C', b'E', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N',
+        b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N',
         b'O', b'P', b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z', b'a', b'b', b'c',
-        b'e', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q',
+        b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q',
         b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z', b'0', b'1', b'2', b'3', b'4', b'5',
         b'6', b'7', b'8', b'9', b' ', b'\'', b'(', b')', b'+', b',', b'-', b'.', b'/', b':', b'=',
         b'?',


### PR DESCRIPTION
Great library!

Removed duplicates of 'E' and 'e' characters in the `PrintableString` character set