### PR TITLE
Fix Clippy warnings

### DIFF
--- a/macros/src/config.rs
+++ b/macros/src/config.rs
@@ -570,12 +570,10 @@ impl<'config> VariantConfig<'config> {
                         } else {
                             quote!(decoder.decode_default_with_tag(tag, #path))
                         }
+                    } else if let Some(constraints) = constraints {
+                        quote!(<_>::decode_with_tag_and_constraints(decoder, tag, #constraints))
                     } else {
-                        if let Some(constraints) = constraints {
-                            quote!(<_>::decode_with_tag_and_constraints(decoder, tag, #constraints))
-                        } else {
-                            quote!(<_>::decode_with_tag(decoder, tag))
-                        }
+                        quote!(<_>::decode_with_tag(decoder, tag))
                     }
                 } else if let Some(path) = field.default {
                     let path = path

--- a/macros/src/enum.rs
+++ b/macros/src/enum.rs
@@ -341,12 +341,10 @@ impl Enum {
                         } else {
                             quote!(#crate_root::Encode::encode_with_tag(value, encoder, #variant_tag))
                         }
-                    } else {
-                        if let Some(constraints) = constraints {
+                    } else if let Some(constraints) = constraints {
                             quote!(#crate_root::Encode::encode_with_constraints(value, encoder, #constraints))
                         } else {
                             quote!(#crate_root::Encode::encode(value, encoder))
-                        }
                     };
 
                     quote! {

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -375,7 +375,7 @@ impl Encoder {
             return self.encode_unconstrained_length(buffer, length, None, encode_fn);
         };
 
-        if matches!(constraints.extensible, None) {
+        if constraints.extensible.is_none() {
             Error::check_length(length, &constraints.constraint)?;
         } else if constraints.constraint.contains(&length) {
             buffer.push(false);
@@ -438,7 +438,7 @@ impl Encoder {
             return self.encode_unconstrained_length(buffer, length, None, encode_fn);
         };
 
-        if matches!(constraints.extensible, None) {
+        if constraints.extensible.is_none() {
             Error::check_length(length, &constraints.constraint)?;
         } else if constraints.constraint.contains(&length) {
             buffer.push(false);
@@ -625,7 +625,7 @@ impl Encoder {
             self.encode_length(buffer, bytes.len(), constraints.size(), |range| {
                 Ok(BitString::from_slice(&bytes[range]))
             })?;
-            return Ok(())
+            return Ok(());
         };
 
         let bytes = match value_range.constraint.effective_bigint_value(value.clone()) {


### PR DESCRIPTION
Fix Clippy warnings on default configuration.

There seems to be also quite many warnings on pedantic level when checking with `﻿﻿cargo clippy -- -W clippy::pedantic` 

Would it be okay to also attempt to fix some of these?