### PR TITLE
Fix OID validation, add docs build for CI, prevent spaces and globbin…

### DIFF
--- a/ci/build.bash
+++ b/ci/build.bash
@@ -19,9 +19,9 @@ required_arg "$TARGET_TRIPLE" '<Target Triple>'
 if [ -z "$RELEASE_BUILD" ]; then
     "$CROSS" build --target "$TARGET_TRIPLE" --workspace
     "$CROSS" build --target "$TARGET_TRIPLE" --all-features --workspace
-    "$CROSS" doc --target "$TARGET_TRIPLE" --release --workspace
+    "$CROSS" doc --no-deps --target "$TARGET_TRIPLE" --release --workspace --target-dir /tmp/rasn-docs
 else
     "$CROSS" build --target "$TARGET_TRIPLE" --all-features --release --workspace
-    "$CROSS" doc --target "$TARGET_TRIPLE" --release --workspace
+    "$CROSS" doc --no-deps --target "$TARGET_TRIPLE" --release --workspace --target-dir /tmp/rasn-docs
 fi
 

--- a/ci/build.bash
+++ b/ci/build.bash
@@ -11,13 +11,17 @@ TARGET_TRIPLE=$2
 # $3 {boolean} = Whether or not building for release or not.
 RELEASE_BUILD=$3
 
-required_arg $CROSS 'CROSS'
-required_arg $TARGET_TRIPLE '<Target Triple>'
+required_arg "$CROSS" 'CROSS'
+required_arg "$TARGET_TRIPLE" '<Target Triple>'
+
+# Build projects. Also test that we can build the docs in crates.io.
 
 if [ -z "$RELEASE_BUILD" ]; then
-    $CROSS build --target $TARGET_TRIPLE --workspace
-    $CROSS build --target $TARGET_TRIPLE --all-features --workspace
+    "$CROSS" build --target "$TARGET_TRIPLE" --workspace
+    "$CROSS" build --target "$TARGET_TRIPLE" --all-features --workspace
+    "$CROSS" doc --target "$TARGET_TRIPLE" --release --workspace
 else
-    $CROSS build --target $TARGET_TRIPLE --all-features --release --workspace
+    "$CROSS" build --target "$TARGET_TRIPLE" --all-features --release --workspace
+    "$CROSS" doc --target "$TARGET_TRIPLE" --release --workspace
 fi
 

--- a/src/types/oid.rs
+++ b/src/types/oid.rs
@@ -4,7 +4,7 @@ pub(crate) const MAX_OID_FIRST_OCTET: u32 = 2;
 pub(crate) const MAX_OID_SECOND_OCTET: u32 = 39;
 
 const fn is_valid_oid(slice: &[u32]) -> bool {
-    slice.len() >= 2 && slice[0] <= MAX_OID_FIRST_OCTET
+    !slice.is_empty() && slice[0] <= MAX_OID_FIRST_OCTET
 }
 
 /// A reference to a global unique identifier that identifies an concept, such
@@ -16,8 +16,8 @@ pub struct Oid([u32]);
 impl Oid {
     /// Creates a new reference to a object identifier from `slice`.
     ///
-    /// Returns `None` if `vec` contains less than two components or the first
-    /// component is greater than 1.
+    /// Returns `None` if `vec` is empty or the first
+    /// component is greater than 2.
     /// ```
     /// use rasn::types::Oid;
     ///
@@ -33,8 +33,8 @@ impl Oid {
 
     /// Creates a new reference to a object identifier from `slice`.
     ///
-    /// Panics if `vec` contains less than two components or the first
-    /// component is greater than 1.
+    /// Panics if `vec` is empty or the first
+    /// component is greater than 2.
     pub const fn const_new(oid: &'static [u32]) -> &'static Self {
         match Self::new(oid) {
             Some(oid) => oid,
@@ -44,8 +44,8 @@ impl Oid {
 
     /// Creates a new mutable reference to a object identifier from `slice`.
     ///
-    /// Returns `None` if `vec` contains less than two components or the first
-    /// component is greater than 1.
+    /// Returns `None` if `vec` is empty or the first
+    /// component is greater than 2.
     /// ```
     /// use rasn::types::Oid;
     ///


### PR DESCRIPTION
There seems to be OIDs with array size of 1 while the valid OID is checked to require size of 2 at least.
This has prevented docs from building.

I modified the requirement to just match that array is not empty.
Is this correct way?

I also added test for CI to check that docs will build before they end up to crates.io