### PR TITLE
Fix/constrained extension

### DIFF
--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -645,7 +645,11 @@ impl<'input> crate::Decoder for Decoder<'input> {
         D::from_tag(self, identifier.tag)
     }
 
-    fn decode_extension_addition<D>(&mut self) -> Result<Option<D>, Self::Error>
+    fn decode_extension_addition_with_constraints<D>(
+        &mut self,
+        // Constraints are irrelevant using BER
+        _: Constraints,
+    ) -> core::result::Result<Option<D>, Self::Error>
     where
         D: Decode,
     {

--- a/src/de.rs
+++ b/src/de.rs
@@ -225,7 +225,48 @@ pub trait Decoder: Sized {
             .unwrap_or_else(default_fn))
     }
 
+    /// Decode a `DEFAULT` value with constraints in a `SEQUENCE` or `SET` with a given `default_fn`.
+    fn decode_default_with_constraints<D: Decode, F: FnOnce() -> D>(
+        &mut self,
+        default_fn: F,
+        constraints: Constraints,
+    ) -> Result<D, Self::Error> {
+        Ok(self
+            .decode_optional_with_constraints::<D>(constraints)?
+            .unwrap_or_else(default_fn))
+    }
+
     fn decode_extension_addition<D>(&mut self) -> Result<Option<D>, Self::Error>
+    where
+        D: Decode,
+    {
+        self.decode_extension_addition_with_constraints(Constraints::default())
+    }
+
+    /// Decode a `DEFAULT` value in a `SEQUENCE`'s or `SET`'s extension
+    fn decode_extension_addition_with_default<D: Decode, F: FnOnce() -> D>(
+        &mut self,
+        default_fn: F,
+    ) -> Result<D, Self::Error> {
+        self.decode_extension_addition_with_default_and_constraints(default_fn, Constraints::default())
+    }
+
+    /// Decode a `DEFAULT` value with constraints in a `SEQUENCE`'s or `SET`'s extension
+    fn decode_extension_addition_with_default_and_constraints<D: Decode, F: FnOnce() -> D>(
+        &mut self,
+        default_fn: F,
+        constraints: Constraints,
+    ) -> Result<D, Self::Error> {
+        Ok(self
+            .decode_extension_addition_with_constraints::<D>(constraints)?
+            .unwrap_or_else(default_fn))
+    }
+
+    /// Decode an extension addition with constraints in a `SEQUENCE` or `SET`
+    fn decode_extension_addition_with_constraints<D>(
+        &mut self,
+        constraints: Constraints,
+    ) -> Result<Option<D>, Self::Error>
     where
         D: Decode;
 

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -302,6 +302,19 @@ pub trait Encoder {
         }
     }
 
+    /// Encode the present constrained value of an optional field.
+    fn encode_default_with_constraints<E: Encode + PartialEq>(
+        &mut self,
+        constraints: Constraints,
+        value: &E,
+        default: impl FnOnce() -> E,
+    ) -> Result<Self::Ok, Self::Error> {
+        match (*value != (default)()).then_some(value) {
+            Some(value) => self.encode_some_with_tag_and_constraints(E::TAG, constraints, value),
+            None => self.encode_none_with_tag(E::TAG),
+        }
+    }
+
     /// Encode a `CHOICE` value.
     fn encode_choice<E: Encode + crate::types::Choice>(
         &mut self,

--- a/src/per.rs
+++ b/src/per.rs
@@ -11,7 +11,7 @@ const THIRTY_TWO_K: u16 = 32768;
 const FOURTY_EIGHT_K: u16 = 49152;
 const SIXTY_FOUR_K: u32 = 65536;
 
-/// Attempts to decode `T` from `input` using DER.
+/// Attempts to decode `T` from `input` using PER.
 pub(crate) fn decode<T: crate::Decode>(
     options: de::DecoderOptions,
     input: &[u8],
@@ -22,7 +22,7 @@ pub(crate) fn decode<T: crate::Decode>(
     ))
 }
 
-/// Attempts to encode `value` to DER.
+/// Attempts to encode `value` to PER.
 pub(crate) fn encode<T: crate::Encode>(
     options: enc::EncoderOptions,
     value: &T,
@@ -34,7 +34,7 @@ pub(crate) fn encode<T: crate::Encode>(
     Ok(enc.output())
 }
 
-/// Attempts to decode `T` from `input` using DER.
+/// Attempts to decode `T` from `input` using PER.
 pub(crate) fn decode_with_constraints<T: crate::Decode>(
     options: de::DecoderOptions,
     constraints: Constraints,
@@ -46,7 +46,7 @@ pub(crate) fn decode_with_constraints<T: crate::Decode>(
     )
 }
 
-/// Attempts to encode `value` to DER.
+/// Attempts to encode `value` to PER.
 pub(crate) fn encode_with_constraints<T: crate::Encode>(
     options: enc::EncoderOptions,
     constraints: Constraints,

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -961,7 +961,10 @@ impl<'input> crate::Decoder for Decoder<'input> {
         D::decode(&mut decoder).map(Some)
     }
 
-    fn decode_extension_addition<D>(&mut self) -> Result<Option<D>, Self::Error>
+    fn decode_extension_addition_with_constraints<D>(
+        &mut self,
+        constraints: Constraints,
+    ) -> core::result::Result<Option<D>, Self::Error>
     where
         D: Decode,
     {
@@ -981,7 +984,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
         let bytes = self.decode_octets()?;
         let mut decoder = Decoder::new(&bytes, self.options);
 
-        D::decode(&mut decoder).map(Some)
+        D::decode_with_constraints(&mut decoder, constraints).map(Some)
     }
 }
 

--- a/src/uper.rs
+++ b/src/uper.rs
@@ -792,4 +792,37 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn constrained_extension_addition() {
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
+        #[rasn(crate_root = "crate")]
+        #[non_exhaustive]
+        struct TestSequence {
+            #[rasn(size("0..=8"))]
+            hello: OctetString,
+            #[rasn(
+                extension_addition,
+                value("0..=9"),
+                default = "test_sequence_world_default"
+            )]
+            world: u8,
+        }
+
+        fn test_sequence_world_default() -> u8 {
+            8
+        }
+
+        let ext_value = TestSequence {
+            hello: bytes::Bytes::from(vec![1, 2, 3, 4]),
+            world: 4,
+        };
+
+        round_trip!(
+            uper,
+            TestSequence,
+            ext_value,
+            &[0xA0, 0x08, 0x10, 0x18, 0x20, 0x08, 0x0A, 0x00]
+        );
+    }
 }


### PR DESCRIPTION
I ran into a problem with constrained extension additions the other day. I represented the following ASN1 snippet...
```asn1
TestSequence ::= SEQUENCE { 
     hello OCTET STRING (SIZE(0..8)),
     ...,
     world INTEGER(0..9) DEFAULT 8
}
```
...using rasn as...
```rust
#[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq)]
#[non_exhaustive]
struct TestSequence {
      #[rasn(size("0..=8"))]
      hello: OctetString,
      #[rasn(
            extension_addition,
            value("0..=9"),
            default = "test_sequence_world_default"
      )]
      world: u8,
}

fn test_sequence_world_default() -> u8 {
     8
}
```
...and discovered that an encoding-decoding round trip fails. I did some digging and it turned out that the decoder does not take constraints into account when dealing with extension additions. This PR provides the test case above and should fix the issue. The crucial fix is in the extension addition function of the per-decoder in `src/per/de.rs`, where I am passing along constraint information.