### PR TITLE
Fix/issue 141

### DIFF
--- a/src/ber/de.rs
+++ b/src/ber/de.rs
@@ -611,7 +611,11 @@ impl<'input> crate::Decoder for Decoder<'input> {
     }
 
     fn decode_optional<D: Decode>(&mut self) -> Result<Option<D>, Self::Error> {
-        self.decode_optional_with_tag(D::TAG)
+        if D::TAG == Tag::EOC {
+            Ok(D::decode(self).ok())
+        } else {
+            self.decode_optional_with_tag(D::TAG)
+        }
     }
 
     /// Decode an the optional value in a `SEQUENCE` or `SET` with `tag`.

--- a/standards/pkix/src/lib.rs
+++ b/standards/pkix/src/lib.rs
@@ -339,7 +339,7 @@ pub struct Extension {
 #[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CertificateList {
     pub tbs_cert_list: TbsCertList,
-    pub signature_algorithim: AlgorithmIdentifier,
+    pub signature_algorithm: AlgorithmIdentifier,
     pub signature: BitString,
 }
 

--- a/standards/pkix/tests/issue141.rs
+++ b/standards/pkix/tests/issue141.rs
@@ -15,3 +15,28 @@ fn issue_141() {
 
     assert_eq!(t, Some(TestTime::Utc("1970-01-01T00:00:10Z".parse().unwrap())));
 }
+
+#[test]
+fn complementary_issue_141() {
+    use rasn::prelude::*;
+
+    /// A general time type.
+    #[derive(AsnType, Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[rasn(choice)]
+    pub enum TestTime {
+        Utc(UtcTime),
+        General(GeneralizedTime),
+    }
+    
+    /// A general time type.
+    #[derive(AsnType, Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[rasn(tag(application, 1))]
+    pub struct TestSeq {
+        pub next_update: Option<TestTime>
+    }
+    
+    let s = &[97, 15, 23, 13, 55, 48, 48, 49, 48, 49, 48, 48, 48, 48, 49, 48, 90];
+    let t: TestSeq = rasn::der::decode(s.as_slice()).unwrap();
+
+    assert_eq!(t, TestSeq { next_update: Some(TestTime::Utc("1970-01-01T00:00:10Z".parse().unwrap())) });
+}

--- a/standards/pkix/tests/issue141.rs
+++ b/standards/pkix/tests/issue141.rs
@@ -1,0 +1,17 @@
+#[test]
+fn issue_141() {
+    use rasn::{prelude::*, AsnType, Decode};
+    
+    /// A general time type.
+    #[derive(AsnType, Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[rasn(choice)]
+    pub enum TestTime {
+        Utc(UtcTime),
+        General(GeneralizedTime),
+    }
+    
+    let s = &[23, 13, 55, 48, 48, 49, 48, 49, 48, 48, 48, 48, 49, 48, 90];
+    let t: Option<TestTime> = rasn::der::decode(s.as_slice()).unwrap();
+
+    assert_eq!(t, Some(TestTime::Utc("1970-01-01T00:00:10Z".parse().unwrap())));
+}


### PR DESCRIPTION
Closes #141 

There was indeed a check for the `EOC` tag missing. Took care of the typo.