### PR TITLE
Fix Result scoping

### DIFF
--- a/macros/src/enum.rs
+++ b/macros/src/enum.rs
@@ -249,7 +249,7 @@ impl Enum {
             quote! {
                 #[automatically_derived]
                 impl #impl_generics #crate_root::types::DecodeChoice for #name #ty_generics #where_clause {
-                    fn from_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> Result<Self, D::Error> {
+                    fn from_tag<D: #crate_root::Decoder>(decoder: &mut D, tag: #crate_root::Tag) -> core::result::Result<Self, D::Error> {
                         use #crate_root::de::Decode;
                         #from_tag
                     }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -150,3 +150,17 @@ pub struct BasicConstraints {
     pub ca: bool,
     pub path_len_constraint: Option<Integer>,
 }
+
+#[test]
+fn result_scoping() {
+    enum Error {}
+    type Result<T> = core::result::Result<T, Error>;
+
+    #[derive(rasn::AsnType, rasn::Encode, rasn::Decode)]
+    #[rasn(choice)]
+    enum Choose {
+        Single(String),
+    }
+
+    let _: Result<()> = Ok(());
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -151,6 +151,8 @@ pub struct BasicConstraints {
     pub path_len_constraint: Option<Integer>,
 }
 
+// This test will fail to compile if `Result` is used in the derive/proc macros instead of
+// `core::result::Result`
 #[test]
 fn result_scoping() {
     enum Error {}


### PR DESCRIPTION
Fixes an instance where `Result` is used in the proc macros instead of `core::result::Result`. Without scoping, any crate-local types named `Result` confuse the compiler.