### PR TITLE
Delegate newtype EOC

### DIFF
--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -27,11 +27,18 @@ pub fn derive_struct_impl(
             }
         } else {
             quote! {
-                <#ty as #crate_root::Decode>::decode_with_tag_and_constraints(
-                    decoder,
-                    tag,
-                    <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(constraints),
-                ).map(Self)
+                match tag {
+                    #crate_root::Tag::EOC => {
+                        Ok(Self(<#ty>::decode(decoder)?))
+                    }
+                    _ => {
+                        <#ty as #crate_root::Decode>::decode_with_tag_and_constraints(
+                            decoder,
+                            tag,
+                            <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(constraints),
+                        ).map(Self)
+                    }
+                }
             }
         }
     } else if config.set {

--- a/macros/src/encode.rs
+++ b/macros/src/encode.rs
@@ -35,12 +35,19 @@ pub fn derive_struct_impl(
             }
         } else {
             quote!(
-                <#ty as #crate_root::Encode>::encode_with_tag_and_constraints(
-                    &self.0,
-                    encoder,
-                    tag,
-                    <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(constraints)
-                )
+                match tag {
+                    #crate_root::Tag::EOC => {
+                        self.0.encode(encoder)
+                    }
+                    _ => {
+                        <#ty as #crate_root::Encode>::encode_with_tag_and_constraints(
+                            &self.0,
+                            encoder,
+                            tag,
+                            <#ty as #crate_root::AsnType>::CONSTRAINTS.override_constraints(constraints)
+                        )
+                    }
+                }
             )
         }
     } else {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -150,3 +150,28 @@ pub struct BasicConstraints {
     pub ca: bool,
     pub path_len_constraint: Option<Integer>,
 }
+
+#[test]
+fn delegated_newtype_wrapping() {
+    #[derive(AsnType, Debug, Decode, Encode, PartialEq)]
+    #[rasn(choice)]
+    enum Hash {
+        #[rasn(tag(explicit(0)))]
+        Sha256(String),
+    }
+
+    #[derive(AsnType, Debug, Decode, Encode, PartialEq)]
+    #[rasn(delegate)]
+    struct TransactionID(Hash);
+
+    #[derive(AsnType, Debug, Decode, Encode, PartialEq)]
+    #[rasn(delegate)]
+    struct PolicyID(TransactionID);
+
+    let policy_id1 = PolicyID(TransactionID(Hash::Sha256("abcdef".into())));
+
+    let ser = rasn::der::encode(&policy_id1).unwrap();
+    assert_eq!(&ser[..], &[160, 8, 12, 6, 97, 98, 99, 100, 101, 102]);
+    let policy_id2: PolicyID = rasn::der::decode(&ser[..]).unwrap();
+    assert_eq!(policy_id1, policy_id2);
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -151,6 +151,8 @@ pub struct BasicConstraints {
     pub path_len_constraint: Option<Integer>,
 }
 
+// This test makes sure that Newtype3(Newtype2(Newtype1(T))) results in serializing
+// as T when using the #[rasn(delegate)] attribute when T is a non-universal type.
 #[test]
 fn delegated_newtype_wrapping() {
     #[derive(AsnType, Debug, Decode, Encode, PartialEq)]


### PR DESCRIPTION
So, this one is probably controversial since it likely constitutes a breaking change. This is basically me scratching an itch with #161.

The scenario is explained in the linked issue, basically I want

```
Newtype3(Newtype2(Newtype1(ComplexType)))
```

where each of the `Newtype`s has `#[rasn(delegate)]` set in the derive macro to directly serialize as `ComplexType`. I added some tests with this PR as well.

If this doesn't get accepted I won't be hurt, but I would like to have some kind of way of doing the above because it's becoming very common for me to wrap some none-rasn-serializable value in another library with a `Newtype(SomeForeignType)` and I don't want to have to write a bunch of serialize/deserialize stuff by hand each time.