### PR TITLE
Gensym field names

### DIFF
--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -131,7 +131,7 @@ pub fn derive_struct_impl(
                 };
 
                 (
-                    quote!(const #const_name: Tag = #tag;),
+                    quote!(const #const_name: #crate_root::Tag = #tag;),
                     quote!((#context, #const_name) => { #choice_name::#field_name(#decode_impl) }),
                     quote!(#choice_name::#field_name(value) => { #set_field_impl })
                 )

--- a/macros/src/encode.rs
+++ b/macros/src/encode.rs
@@ -119,7 +119,8 @@ pub fn map_to_inner_type(
 
             let init_fields = fields.iter().map(|field| {
                 let name = field.ident.as_ref().unwrap();
-                quote!(#name : &#name)
+                let name_prefixed = format_ident!("__rasn_field_{}", name);
+                quote!(#name : &#name_prefixed)
             });
 
             fn wrap(
@@ -182,8 +183,11 @@ fn fields_as_vars(fields: &syn::Fields) -> impl Iterator<Item = proc_macro2::Tok
 
         let name = field
             .ident
-            .is_some()
-            .then(|| self_name.clone())
+            .as_ref()
+            .map(|ident| {
+                let prefixed = format_ident!("__rasn_field_{}", ident);
+                quote!(#prefixed)
+            })
             .unwrap_or_else(|| {
                 let ident = format_ident!("i{}", i);
                 quote!(#ident)

--- a/macros/src/enum.rs
+++ b/macros/src/enum.rs
@@ -312,6 +312,11 @@ impl Enum {
                         let ident = f.ident.as_ref().unwrap();
                         quote!(#ident)
                     });
+                    let idents_prefixed = v.fields.iter().map(|f| {
+                        let ident = f.ident.as_ref().unwrap();
+                        let ident_prefixed = format_ident!("__rasn_field_{}", ident);
+                        quote!(#ident_prefixed)
+                    });
 
                     let tag_tokens = variant_tag.to_tokens(crate_root);
                     let encode_impl = crate::encode::map_to_inner_type(
@@ -323,7 +328,7 @@ impl Enum {
                         variant_config.has_explicit_tag(),
                     );
 
-                    quote!(#name::#ident { #(#idents),* } => { #encode_impl.map(|_| #tag_tokens) })
+                    quote!(#name::#ident { #(#idents: #idents_prefixed),* } => { #encode_impl.map(|_| #tag_tokens) })
                 }
                 syn::Fields::Unnamed(_) => {
                     if v.fields.iter().count() != 1 {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -193,3 +193,20 @@ fn result_scoping() {
 
     let _: Result<()> = Ok(());
 }
+
+// This makes sure enum fields can have a field named "tag"
+#[test]
+fn enum_with_tag_name_variant() {
+    #[derive(AsnType, Encode, Decode)]
+    #[rasn(choice)]
+    enum MyEnum {
+        #[rasn(tag(explicit(0)))]
+        HasTagField {
+            #[rasn(tag(explicit(0)))]
+            note_id: u8,
+            // we should allow named enum fields called "tag"
+            #[rasn(tag(explicit(1)))]
+            tag: String,
+        },
+    }
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -194,17 +194,16 @@ fn result_scoping() {
     let _: Result<()> = Ok(());
 }
 
-// This makes sure enum fields can have a field named "tag"
+// This makes sure enum fields can have a field named `encoder` or `tag`
 #[test]
-fn enum_with_tag_name_variant() {
+fn enum_with_encoder_tag_name_variants() {
     #[derive(AsnType, Encode, Decode)]
     #[rasn(choice)]
     enum MyEnum {
         #[rasn(tag(explicit(0)))]
-        HasTagField {
+        HasConflictingFields {
             #[rasn(tag(explicit(0)))]
-            note_id: u8,
-            // we should allow named enum fields called "tag"
+            encoder: String,
             #[rasn(tag(explicit(1)))]
             tag: String,
         },


### PR DESCRIPTION
Use "gensym" idents when enumerating named fields. instead of raw field names (ie `name`, `tag`, etc), prefix the fields
with `__rasn_field_`: `__rasn_field_name`, `__rasn_field_tag`, etc.

This is so an enum like this can compile (it does not compile without this PR):

```rust
#[derive(AsnType, Decode, Encode)]
#[rasn(choice)]
enum MyEnum {
    #[rasn(tag(explicit(0)))]
    SomeVariant {
        #[rasn(tag(explicit(0)))]
	encoder: String,
        #[rasn(tag(explicit(1)))]
	tag: String,
    }
}
```

The idents `encoder` and `tag` conflict with the function args `encoder`/`tag` generated by the derive macro. In other words, it's not possible to have named enum variants of `encoder`, `tag`, or `constraints` because they conflict with the derived function definition.

This fixes things by prefixing the generated variable names.
