### PR TITLE
Fix/issue 165

### DIFF
--- a/macros/src/encode.rs
+++ b/macros/src/encode.rs
@@ -153,11 +153,11 @@ pub fn map_to_inner_type(
         syn::Fields::Unit => (quote!(;), quote!()),
     };
 
+    let tag = tag.to_tokens(crate_root);
     let inner_impl = if is_explicit {
-        let tag = tag.to_tokens(crate_root);
         quote!(encoder.encode_explicit_prefix(#tag, &inner).map(drop))
     } else {
-        quote!(inner.encode(encoder))
+        quote!(inner.encode_with_tag(encoder, #tag))
     };
 
     quote! {

--- a/tests/issue165.rs
+++ b/tests/issue165.rs
@@ -1,0 +1,23 @@
+use rasn::{types::*, *};
+
+#[test]
+fn decode_implicitly_tagged_vec_choice() {
+    #[derive(Debug, Clone, AsnType, Encode, Decode, PartialEq)]
+        #[rasn(choice)]
+        pub enum MultisigPolicySignature {
+            #[rasn(tag(0))]
+            Key {
+                #[rasn(tag(0))]
+                key: String,
+            },
+        }
+
+    let transactions2 = vec![MultisigPolicySignature::Key {
+        key: String::from("key1"),
+    }];
+
+    let ser2 = rasn::der::encode(&transactions2).unwrap();
+    let transactions2_2: Vec<MultisigPolicySignature> = rasn::der::decode(&ser2[..]).unwrap();
+    assert_eq!(transactions2_2.len(), 1);
+    assert_eq!(transactions2_2.first().unwrap(), &MultisigPolicySignature::Key { key: String::from("key1") });
+}


### PR DESCRIPTION
Closes #165 

I cross-checked the encoding output in the issue using [asn1.io](https://asn1.io/asn1playground/), assuming the following ASN1 to represent the struct mentioned [here](https://github.com/XAMPPRocky/rasn/issues/165#issuecomment-1741602093):
```asn1
    Issue-165 DEFINITIONS IMPLICIT TAGS ::=
    BEGIN

    Signatures ::= SEQUENCE OF MultisigPolicySignature

    MultisigPolicySignature ::= CHOICE {
        key [0] SEQUENCE {
            key [0] UTF8String
        }
    }

    END
```
When encoding nested `SEQUENCE`s, the `rasn` encoder did not take the custom tag into account, which in case of the nestes `key`-`SEQUENCE` and was producing a wrong tag, i.e. `UNIVERSAL 0`. I changed the call in the macro for encoding inner items from a simple `encode` to `encode_with_tag`. The tests run fine, and I tried to trace the different cases we could encounter through the macro process and I couldn't find any side-effects on other cases. You'll likely have a much more complete view of how the different macro calls come together, @XAMPPRocky.

Let me know if I need to do more digging.