### PR TITLE
Fix/uper integer

### DIFF
--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -381,7 +381,7 @@ impl<'input> Decoder<'input> {
                         .checked_mul(8)
                         .ok_or(Error::exceeds_max_length(u32::MAX.into()))?;
                     self.parse_non_negative_binary_integer(super::range_from_bits(range))?
-                },
+                }
                 (_, _) => self.parse_non_negative_binary_integer(range)?,
             }
         } else {

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -381,15 +381,7 @@ impl<'input> Decoder<'input> {
                         .checked_mul(8)
                         .ok_or(Error::exceeds_max_length(u32::MAX.into()))?;
                     self.parse_non_negative_binary_integer(super::range_from_bits(range))?
-                }
-                (false, OVER_K64..) => {
-                    let bytes = to_vec(&self.decode_octets()?);
-                    value_constraint
-                        .constraint
-                        .as_start()
-                        .map(|_| num_bigint::BigUint::from_bytes_be(&bytes).into())
-                        .unwrap_or_else(|| num_bigint::BigInt::from_signed_bytes_be(&bytes))
-                }
+                },
                 (_, _) => self.parse_non_negative_binary_integer(range)?,
             }
         } else {

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -678,11 +678,6 @@ impl Encoder {
                         );
                     }
                 }
-                (false, OVER_K64..) => {
-                    self.encode_length(buffer, bytes.len(), <_>::default(), |range| {
-                        Ok(BitString::from_slice(&bytes[range]))
-                    })?;
-                }
                 (_, _) => self.encode_non_negative_binary_integer(buffer, range, &bytes),
             }
         } else {


### PR DESCRIPTION
If a value range can be determined for a given integer, `uper` does not handle values larger than 64K differently than those smaller than 64K.

#### ITU-T X.691 Reference
```
11.5.6	In the case of the UNALIGNED variant the value ("n" – "lb") shall be encoded 
as a non-negative binary integer in a bit field as specified in 11.3 with the minimum number 
of bits necessary to represent the range.
```