### PR TITLE
fix(per): pad non-negative binary integer slice at start

### DIFF
--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -342,7 +342,7 @@ impl<'input> Decoder<'input> {
             data.to_bitvec()
         };
 
-        Ok(num_bigint::BigUint::from_bytes_be(&to_vec(&data)).into())
+        Ok(num_bigint::BigUint::from_bytes_be(&to_vec(&data, true)).into())
     }
 
     fn parse_integer(&mut self, constraints: Constraints) -> Result<types::Integer> {
@@ -350,7 +350,7 @@ impl<'input> Decoder<'input> {
         let value_constraint = constraints.value();
 
         let Some(value_constraint) = value_constraint.filter(|_| !extensible) else {
-            let bytes = to_vec(&self.decode_octets()?);
+            let bytes = to_vec(&self.decode_octets()?, false);
             return Ok(num_bigint::BigInt::from_signed_bytes_be(&bytes));
         };
 
@@ -385,7 +385,7 @@ impl<'input> Decoder<'input> {
                 (_, _) => self.parse_non_negative_binary_integer(range)?,
             }
         } else {
-            let bytes = to_vec(&self.decode_octets()?);
+            let bytes = to_vec(&self.decode_octets()?, false);
             value_constraint
                 .constraint
                 .as_start()
@@ -567,7 +567,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
             Ok(input)
         })?;
 
-        Ok(types::Any::new(to_vec(&octet_string)))
+        Ok(types::Any::new(to_vec(&octet_string, false)))
     }
 
     fn decode_bool(&mut self, _: Tag) -> Result<bool> {
@@ -992,11 +992,11 @@ mod tests {
     fn bitvec() {
         use bitvec::prelude::*;
         assert_eq!(
-            to_vec(bitvec::bits![u8, Msb0;       0, 0, 0, 1, 1, 1, 0, 1]),
+            to_vec(bitvec::bits![u8, Msb0;       0, 0, 0, 1, 1, 1, 0, 1], false),
             vec![29]
         );
         assert_eq!(
-            to_vec(&bitvec::bits![u8, Msb0; 1, 1, 0, 0, 0, 1, 1, 1, 0, 1][2..]),
+            to_vec(&bitvec::bits![u8, Msb0; 1, 1, 0, 0, 0, 1, 1, 1, 0, 1][2..], false),
             vec![29]
         );
     }

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -99,7 +99,7 @@ impl Encoder {
     pub fn output(self) -> Vec<u8> {
         let mut output = self.bitstring_output();
         Self::force_pad_to_alignment(&mut output);
-        super::to_vec(&output)
+        super::to_vec(&output, false)
     }
 
     pub fn bitstring_output(self) -> BitString {

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -67,7 +67,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             index_string.extend(padding);
         }
 
-        crate::per::to_vec(&index_string)
+        crate::per::to_vec(&index_string, false)
     }
 
     fn octet_aligned_char_width(&self) -> u32 {
@@ -96,7 +96,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             octet_string
                 .extend_from_bitslice(&ch.view_bits::<Msb0>()[(u32::BITS - width) as usize..]);
         }
-        crate::per::to_vec(&octet_string)
+        crate::per::to_vec(&octet_string, false)
     }
 
     fn character_width() -> u32 {


### PR DESCRIPTION
The workaround `to_vec` function in `src/per` works fine in all cases but when decoding non-negative binary integers. To be read correctly into a `BigUint`, the bitslice needs to be padded at the start. I added an additional parameter to specify where padding should be inserted when converting the bitslice to `Vec<u8>`.

If you have a minute, @XAMPPRocky, could you let me know if there is a more elegant way of handling the two cases [in `to_vec`](https://github.com/6d7a/rasn/blob/8e275504e9c58d3398fc024f63e7c691ca24e6bc/src/per.rs#L78)?

Thanks

