### PR TITLE
Fix: four uper issues

### DIFF
--- a/macros/src/enum.rs
+++ b/macros/src/enum.rs
@@ -86,6 +86,8 @@ impl Enum {
             }
         });
 
+        let extensible = self.config.constraints.extensible;
+
         let enumerated_impl = self.config.enumerated.then(|| {
             let (variants, extended_variants): (Vec<_>, Vec<_>) = self.variants.iter()
                 .map(|variant| VariantConfig::new(variant, &self.generics, &self.config))
@@ -104,7 +106,7 @@ impl Enum {
 
             let variants = variants.iter().map(|config| config.variant.ident.clone());
             let extended_variant_idents = extended_variants.iter().map(|config| config.variant.ident.clone());
-            let extended_variants = (!extended_variants.is_empty())
+            let extended_variants = extensible
                 .then(|| quote!(Some(&[#(Self::#extended_variant_idents,)*])))
                 .unwrap_or(quote!(None));
             let extended_discriminants = (!extended_variants.is_empty())

--- a/src/per.rs
+++ b/src/per.rs
@@ -87,7 +87,7 @@ pub(crate) fn to_left_padded_vec(slice: &bitvec::slice::BitSlice<u8, bitvec::ord
     let mut vec = Vec::new();
 
     let missing_bits = 8 - slice.len() % 8;
-    if missing_bits != 8 {
+    if missing_bits == 8 {
         to_vec(slice)
     } else {
         let mut padding = bitvec::bitvec![u8, bitvec::prelude::Msb0; 0; missing_bits];

--- a/src/per.rs
+++ b/src/per.rs
@@ -70,33 +70,31 @@ pub(crate) fn range_from_bits(bits: u32) -> i128 {
 // Workaround for https://github.com/ferrilab/bitvec/issues/228
 pub(crate) fn to_vec(
     slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>,
-    pad_start: bool,
 ) -> Vec<u8> {
     use bitvec::prelude::*;
     let mut vec = Vec::new();
 
-    if pad_start {
-        for slice in pad(slice).chunks(8) {
-            vec.push(slice.load_be());
-        }
-    } else {
-        for slice in slice.chunks(8) {
-            vec.push(slice.load_be());
-        }
+    for slice in slice.chunks(8) {
+        vec.push(slice.load_be());
     }
 
     vec
 }
 
-fn pad(
-    output: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>,
-) -> bitvec::prelude::BitVec<u8, bitvec::order::Msb0> {
-    let missing_bits = 8 - output.len() % 8;
-    if missing_bits == 8 {
-        output.to_bitvec()
+pub(crate) fn to_left_padded_vec(slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>) -> Vec<u8> {
+    use bitvec::prelude::*;
+
+    let mut vec = Vec::new();
+
+    let missing_bits = 8 - slice.len() % 8;
+    if missing_bits != 8 {
+        to_vec(slice)
     } else {
         let mut padding = bitvec::bitvec![u8, bitvec::prelude::Msb0; 0; missing_bits];
-        padding.append(&mut output.to_bitvec());
-        padding
+        padding.append(&mut slice.to_bitvec());
+        for s in padding.chunks(8) {
+            vec.push(s.load_be());
+        }
+        vec
     }
 }

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -342,7 +342,7 @@ impl<'input> Decoder<'input> {
             data.to_bitvec()
         };
 
-        Ok(num_bigint::BigUint::from_bytes_be(&to_vec(&data)).into())
+        Ok(num_bigint::BigUint::from_bytes_be(&to_vec(&data, true)).into())
     }
 
     fn parse_integer(&mut self, constraints: Constraints) -> Result<types::Integer> {
@@ -350,7 +350,7 @@ impl<'input> Decoder<'input> {
         let value_constraint = constraints.value();
 
         let Some(value_constraint) = value_constraint.filter(|_| !extensible) else {
-            let bytes = to_vec(&self.decode_octets()?);
+            let bytes = to_vec(&self.decode_octets()?, false);
             return Ok(num_bigint::BigInt::from_signed_bytes_be(&bytes));
         };
 
@@ -385,7 +385,7 @@ impl<'input> Decoder<'input> {
                 (_, _) => self.parse_non_negative_binary_integer(range)?,
             }
         } else {
-            let bytes = to_vec(&self.decode_octets()?);
+            let bytes = to_vec(&self.decode_octets()?, false);
             value_constraint
                 .constraint
                 .as_start()
@@ -567,7 +567,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
             Ok(input)
         })?;
 
-        Ok(types::Any::new(to_vec(&octet_string)))
+        Ok(types::Any::new(to_vec(&octet_string, false)))
     }
 
     fn decode_bool(&mut self, _: Tag) -> Result<bool> {
@@ -992,11 +992,11 @@ mod tests {
     fn bitvec() {
         use bitvec::prelude::*;
         assert_eq!(
-            to_vec(bitvec::bits![u8, Msb0;       0, 0, 0, 1, 1, 1, 0, 1]),
+            to_vec(bitvec::bits![u8, Msb0;       0, 0, 0, 1, 1, 1, 0, 1], false),
             vec![29]
         );
         assert_eq!(
-            to_vec(&bitvec::bits![u8, Msb0; 1, 1, 0, 0, 0, 1, 1, 1, 0, 1][2..]),
+            to_vec(&bitvec::bits![u8, Msb0; 1, 1, 0, 0, 0, 1, 1, 1, 0, 1][2..], false),
             vec![29]
         );
     }

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -99,7 +99,7 @@ impl Encoder {
     pub fn output(self) -> Vec<u8> {
         let mut output = self.bitstring_output();
         Self::force_pad_to_alignment(&mut output);
-        super::to_vec(&output, false)
+        super::to_vec(&output)
     }
 
     pub fn bitstring_output(self) -> BitString {

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -99,7 +99,7 @@ impl Encoder {
     pub fn output(self) -> Vec<u8> {
         let mut output = self.bitstring_output();
         Self::force_pad_to_alignment(&mut output);
-        super::to_vec(&output)
+        super::to_vec(&output, false)
     }
 
     pub fn bitstring_output(self) -> BitString {

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1113,7 +1113,9 @@ impl crate::Encoder for Encoder {
                 }
                 self.encode_octet_string_into_buffer(<_>::default(), &output, &mut buffer)?;
             }
-            (_, None) => {}
+            (_, None) => {
+                buffer.extend(choice_encoder.output);
+            }
         }
 
         self.extend(tag, &buffer);

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -67,7 +67,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             index_string.extend(padding);
         }
 
-        crate::per::to_vec(&index_string)
+        crate::per::to_vec(&index_string, false)
     }
 
     fn octet_aligned_char_width(&self) -> u32 {
@@ -96,7 +96,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             octet_string
                 .extend_from_bitslice(&ch.view_bits::<Msb0>()[(u32::BITS - width) as usize..]);
         }
-        crate::per::to_vec(&octet_string)
+        crate::per::to_vec(&octet_string, false)
     }
 
     fn character_width() -> u32 {

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -67,7 +67,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             index_string.extend(padding);
         }
 
-        crate::per::to_vec(&index_string, false)
+        crate::per::to_vec(&index_string)
     }
 
     fn octet_aligned_char_width(&self) -> u32 {
@@ -96,7 +96,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             octet_string
                 .extend_from_bitslice(&ch.view_bits::<Msb0>()[(u32::BITS - width) as usize..]);
         }
-        crate::per::to_vec(&octet_string, false)
+        crate::per::to_vec(&octet_string)
     }
 
     fn character_width() -> u32 {


### PR DESCRIPTION
Closes #176 

This PR fixes four small (u)per issues:
* non-negative binary integer slices were padded right instead of left (I refactored #176 into two separate functions for the different padding use cases)
* extensible ENUMERATED without extended variants was treaded like non-extensible ENUMERATED
* contents of CHOICEs with only one option were not encoded
* extended INTEGERs were not encoded correctly