### PR TITLE
Move some generally useful functions from PER to utility module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod types;
 // Data Formats
 
 mod per;
+mod utils;
 
 pub mod aper;
 pub mod ber;

--- a/src/per.rs
+++ b/src/per.rs
@@ -2,7 +2,6 @@ pub mod de;
 pub mod enc;
 
 use crate::types::Constraints;
-use alloc::vec::Vec;
 
 pub use self::{de::Decoder, enc::Encoder};
 
@@ -57,44 +56,4 @@ pub(crate) fn encode_with_constraints<T: crate::Encode>(
     value.encode_with_constraints(&mut enc, constraints)?;
 
     Ok(enc.output())
-}
-
-pub(crate) const fn log2(x: i128) -> u32 {
-    i128::BITS - (x - 1).leading_zeros()
-}
-
-pub(crate) fn range_from_bits(bits: u32) -> i128 {
-    2i128.pow(bits) - 1
-}
-
-// Workaround for https://github.com/ferrilab/bitvec/issues/228
-pub(crate) fn to_vec(slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>) -> Vec<u8> {
-    use bitvec::prelude::*;
-    let mut vec = Vec::new();
-
-    for slice in slice.chunks(8) {
-        vec.push(slice.load_be());
-    }
-
-    vec
-}
-
-pub(crate) fn to_left_padded_vec(
-    slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>,
-) -> Vec<u8> {
-    use bitvec::prelude::*;
-
-    let mut vec = Vec::new();
-
-    let missing_bits = 8 - slice.len() % 8;
-    if missing_bits == 8 {
-        to_vec(slice)
-    } else {
-        let mut padding = bitvec::bitvec![u8, bitvec::prelude::Msb0; 0; missing_bits];
-        padding.append(&mut slice.to_bitvec());
-        for s in padding.chunks(8) {
-            vec.push(s.load_be());
-        }
-        vec
-    }
 }

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -107,7 +107,7 @@ impl Encoder {
     pub fn output(self) -> Vec<u8> {
         let mut output = self.bitstring_output();
         Self::force_pad_to_alignment(&mut output);
-        super::to_vec(&output)
+        crate::utils::to_vec(&output)
     }
 
     pub fn bitstring_output(self) -> BitString {
@@ -203,7 +203,7 @@ impl Encoder {
         let is_large_string = if let Some(size) = constraints.size() {
             let width = match constraints.permitted_alphabet() {
                 Some(alphabet) => {
-                    self.character_width(super::log2(alphabet.constraint.len() as i128))
+                    self.character_width(crate::utils::log2(alphabet.constraint.len() as i128))
                 }
                 None => self.character_width(S::CHARACTER_WIDTH),
             };
@@ -233,7 +233,8 @@ impl Encoder {
         match constraints.permitted_alphabet() {
             Some(alphabet)
                 if S::CHARACTER_WIDTH
-                    > self.character_width(super::log2(alphabet.constraint.len() as i128)) =>
+                    > self
+                        .character_width(crate::utils::log2(alphabet.constraint.len() as i128)) =>
             {
                 let alphabet = &alphabet.constraint;
                 let characters = &DynConstrainedCharacterString::from_bits(value.chars(), alphabet)
@@ -421,8 +422,8 @@ impl Encoder {
                     let effective_length = constraints.effective_value(length).into_inner();
                     let range = (self.options.aligned && range > 256)
                         .then(|| {
-                            let range = super::log2(range as i128);
-                            super::range_from_bits(
+                            let range = crate::utils::log2(range as i128);
+                            crate::utils::range_from_bits(
                                 range
                                     .is_power_of_two()
                                     .then_some(range)
@@ -644,7 +645,8 @@ impl Encoder {
                     self.encode_non_negative_binary_integer(buffer, K64, &bytes);
                 }
                 (true, OVER_K64..) => {
-                    let range_len_in_bytes = num_integer::div_ceil(super::log2(range), 8) as i128;
+                    let range_len_in_bytes =
+                        num_integer::div_ceil(crate::utils::log2(range), 8) as i128;
 
                     if effective_value == 0 {
                         self.encode_non_negative_binary_integer(
@@ -656,7 +658,8 @@ impl Encoder {
                         self.encode_non_negative_binary_integer(&mut *buffer, 255, &bytes);
                     } else {
                         let range_value_in_bytes =
-                            num_integer::div_ceil(super::log2(effective_value + 1), 8) as i128;
+                            num_integer::div_ceil(crate::utils::log2(effective_value + 1), 8)
+                                as i128;
                         self.encode_non_negative_binary_integer(
                             buffer,
                             range_len_in_bytes,
@@ -665,7 +668,7 @@ impl Encoder {
                         self.pad_to_alignment(&mut *buffer);
                         self.encode_non_negative_binary_integer(
                             &mut *buffer,
-                            super::range_from_bits(range_value_in_bytes as u32 * 8),
+                            crate::utils::range_from_bits(range_value_in_bytes as u32 * 8),
                             &bytes,
                         );
                     }
@@ -688,7 +691,7 @@ impl Encoder {
         bytes: &[u8],
     ) {
         use core::cmp::Ordering;
-        let total_bits = super::log2(range) as usize;
+        let total_bits = crate::utils::log2(range) as usize;
         let bits = BitVec::<u8, Msb0>::from_slice(bytes);
         let bits = match total_bits.cmp(&bits.len()) {
             Ordering::Greater => {

--- a/src/types/strings/constrained.rs
+++ b/src/types/strings/constrained.rs
@@ -9,7 +9,7 @@ use crate::types;
 
 pub(crate) trait StaticPermittedAlphabet: Sized + Default {
     const CHARACTER_SET: &'static [u32];
-    const CHARACTER_WIDTH: u32 = crate::per::log2(Self::CHARACTER_SET.len() as i128);
+    const CHARACTER_WIDTH: u32 = crate::utils::log2(Self::CHARACTER_SET.len() as i128);
 
     fn push_char(&mut self, ch: u32);
     fn chars(&self) -> Box<dyn Iterator<Item = u32> + '_>;
@@ -56,7 +56,7 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             index_string.extend(padding);
         }
 
-        crate::per::to_vec(&index_string)
+        crate::utils::to_vec(&index_string)
     }
 
     fn octet_aligned_char_width(&self) -> u32 {
@@ -85,11 +85,11 @@ pub(crate) trait StaticPermittedAlphabet: Sized + Default {
             octet_string
                 .extend_from_bitslice(&ch.view_bits::<Msb0>()[(u32::BITS - width) as usize..]);
         }
-        crate::per::to_vec(&octet_string)
+        crate::utils::to_vec(&octet_string)
     }
 
     fn character_width() -> u32 {
-        crate::per::log2(Self::CHARACTER_SET.len() as i128)
+        crate::utils::log2(Self::CHARACTER_SET.len() as i128)
     }
 
     fn len(&self) -> usize {
@@ -160,7 +160,7 @@ pub(crate) fn try_from_permitted_alphabet<S: StaticPermittedAlphabet>(
     alphabet: &BTreeMap<u32, u32>,
 ) -> Result<S, PermittedAlphabetError> {
     let mut string = S::default();
-    let permitted_alphabet_char_width = crate::per::log2(alphabet.len() as i128);
+    let permitted_alphabet_char_width = crate::utils::log2(alphabet.len() as i128);
     // Alphabet should be always indexed key-alphabetvalue pairs at this point
     let values_only = alphabet.values().copied().collect::<Vec<u32>>();
     if should_be_indexed(permitted_alphabet_char_width, &values_only) {
@@ -202,7 +202,7 @@ impl DynConstrainedCharacterString {
         character_set: &[u32],
     ) -> Result<Self, PermittedAlphabetError> {
         let mut buffer = types::BitString::new();
-        let char_width = crate::per::log2(character_set.len() as i128);
+        let char_width = crate::utils::log2(character_set.len() as i128);
         let indexed = should_be_indexed(char_width, character_set);
         let alphabet: BTreeMap<u32, u32>;
         if indexed {
@@ -239,7 +239,7 @@ impl DynConstrainedCharacterString {
     }
 
     pub fn character_width(&self) -> usize {
-        crate::per::log2(self.character_set.len() as i128) as usize
+        crate::utils::log2(self.character_set.len() as i128) as usize
     }
 
     #[allow(unused)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,43 @@
+//! Module for different utility functions which are used in the library.
+
+use alloc::vec::Vec;
+
+pub(crate) const fn log2(x: i128) -> u32 {
+    i128::BITS - (x - 1).leading_zeros()
+}
+
+pub(crate) fn range_from_bits(bits: u32) -> i128 {
+    2i128.pow(bits) - 1
+}
+
+// Workaround for https://github.com/ferrilab/bitvec/issues/228
+pub(crate) fn to_vec(slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>) -> Vec<u8> {
+    use bitvec::prelude::*;
+    let mut vec = Vec::new();
+
+    for slice in slice.chunks(8) {
+        vec.push(slice.load_be());
+    }
+
+    vec
+}
+
+pub(crate) fn to_left_padded_vec(
+    slice: &bitvec::slice::BitSlice<u8, bitvec::order::Msb0>,
+) -> Vec<u8> {
+    use bitvec::prelude::*;
+
+    let mut vec = Vec::new();
+
+    let missing_bits = 8 - slice.len() % 8;
+    if missing_bits == 8 {
+        to_vec(slice)
+    } else {
+        let mut padding = bitvec::bitvec![u8, bitvec::prelude::Msb0; 0; missing_bits];
+        padding.append(&mut slice.to_bitvec());
+        for s in padding.chunks(8) {
+            vec.push(s.load_be());
+        }
+        vec
+    }
+}


### PR DESCRIPTION
I think these functions (log2, to_vec etc.) might be better located on `utils.rs` or something similar, since they are not codec specific. For example, OER needs them as well.