### PR TITLE
Field_error improved, Boxed error `kind`, explicit naming also for `DecodeErrorKind`

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -318,11 +318,7 @@ pub trait Error: core::fmt::Display {
     /// Creates a new error about being unable to decode a field in a compound
     /// type, such as a set or sequence.
     #[must_use]
-    fn field_error<D: core::fmt::Display>(
-        name: &'static str,
-        error: D,
-        codec: crate::Codec,
-    ) -> Self;
+    fn field_error(name: &'static str, error: DecodeError, codec: crate::Codec) -> Self;
     /// Creates a new error about finding a duplicate field.
     #[must_use]
     fn duplicate_field(name: &'static str, codec: crate::Codec) -> Self;

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -1,5 +1,5 @@
 use super::strings::PermittedAlphabetError;
-use alloc::string::ToString;
+use alloc::{boxed::Box, string::ToString};
 
 use snafu::{Backtrace, GenerateImplicitData, Snafu};
 
@@ -81,8 +81,8 @@ impl From<CodecDecodeError> for DecodeError {
 ///                 break;
 ///             }
 ///             Err(e) => {
-///                 // e is DecodeError
-///                 match e.kind {
+///                 // e is DecodeError, kind is boxed
+///                 match *e.kind {
 ///                     DecodeErrorKind::Incomplete { needed } => {
 ///                         println!("Codec error source: {}", e.codec);
 ///                         println!("Error kind: {}", e.kind);
@@ -94,15 +94,16 @@ impl From<CodecDecodeError> for DecodeError {
 ///                             Needed::Size(n) => {
 ///                                 let missing_bytes = n.get() / 7;
 ///                                 missing_bytes
+///                                
 ///                             }
 ///                             _ => {
-///                                 println!("Backtrace:\n{}", e.backtrace);
+///                                 println!("Backtrace:\n{:?}", e.backtrace);
 ///                                 panic!("Unexpected error! {e:?}");
 ///                             }
 ///                         }
 ///                     }
 ///                     k => {
-///                         println!("Backtrace:\n{}", e.backtrace);
+///                         println!("Backtrace:\n{:?}", e.backtrace);
 ///                         panic!("Unexpected error! {k:?}");
 ///                     }
 ///                 }
@@ -118,24 +119,38 @@ impl From<CodecDecodeError> for DecodeError {
 /// Successful decoding!
 /// Decoded string: Hello, world!
 /// ```
-#[derive(Snafu, Debug)]
-#[snafu(visibility(pub))]
-#[snafu(display("Error Kind: {}\nBacktrace:\n{}", kind, backtrace))]
+#[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct DecodeError {
-    pub kind: Kind,
+    pub kind: Box<DecodeErrorKind>,
     pub codec: Codec,
-    pub backtrace: Backtrace,
+    pub backtrace: Option<Backtrace>,
+}
+impl core::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "Error Kind: {}", self.kind)?;
+        writeln!(f, "Codec: {}", self.kind)?;
+        if let Some(ref bt) = self.backtrace {
+            write!(f, "\nBacktrace:\n{bt}")?;
+        }
+        Ok(())
+    }
 }
 
 impl DecodeError {
     #[must_use]
     pub fn alphabet_constraint_not_satisfied(reason: PermittedAlphabetError, codec: Codec) -> Self {
-        Self::from_kind(Kind::AlphabetConstraintNotSatisfied { reason }, codec)
+        Self::from_kind(
+            DecodeErrorKind::AlphabetConstraintNotSatisfied { reason },
+            codec,
+        )
     }
     #[must_use]
     pub fn range_exceeds_platform_width(needed: u32, present: u32, codec: Codec) -> Self {
-        Self::from_kind(Kind::RangeExceedsPlatformWidth { needed, present }, codec)
+        Self::from_kind(
+            DecodeErrorKind::RangeExceedsPlatformWidth { needed, present },
+            codec,
+        )
     }
     #[must_use]
     pub fn fixed_string_conversion_failed(
@@ -145,7 +160,7 @@ impl DecodeError {
         codec: Codec,
     ) -> Self {
         Self::from_kind(
-            Kind::FixedStringConversionFailed {
+            DecodeErrorKind::FixedStringConversionFailed {
                 tag,
                 actual,
                 expected,
@@ -156,21 +171,21 @@ impl DecodeError {
     #[must_use]
     pub fn incorrect_item_number_in_sequence(expected: usize, actual: usize, codec: Codec) -> Self {
         Self::from_kind(
-            Kind::IncorrectItemNumberInSequence { expected, actual },
+            DecodeErrorKind::IncorrectItemNumberInSequence { expected, actual },
             codec,
         )
     }
     #[must_use]
     pub fn integer_overflow(max_width: u32, codec: Codec) -> Self {
-        Self::from_kind(Kind::IntegerOverflow { max_width }, codec)
+        Self::from_kind(DecodeErrorKind::IntegerOverflow { max_width }, codec)
     }
     #[must_use]
     pub fn integer_type_conversion_failed(msg: alloc::string::String, codec: Codec) -> Self {
-        Self::from_kind(Kind::IntegerTypeConversionFailed { msg }, codec)
+        Self::from_kind(DecodeErrorKind::IntegerTypeConversionFailed { msg }, codec)
     }
     #[must_use]
     pub fn invalid_bit_string(bits: u8, codec: Codec) -> Self {
-        Self::from_kind(Kind::InvalidBitString { bits }, codec)
+        Self::from_kind(DecodeErrorKind::InvalidBitString { bits }, codec)
     }
     #[must_use]
     pub fn missing_tag_class_or_value_in_sequence_or_set(
@@ -179,28 +194,39 @@ impl DecodeError {
         codec: Codec,
     ) -> Self {
         Self::from_kind(
-            Kind::MissingTagClassOrValueInSequenceOrSet { class, value },
+            DecodeErrorKind::MissingTagClassOrValueInSequenceOrSet { class, value },
             codec,
         )
     }
 
     #[must_use]
     pub fn type_not_extensible(codec: Codec) -> Self {
-        Self::from_kind(Kind::TypeNotExtensible, codec)
+        Self::from_kind(DecodeErrorKind::TypeNotExtensible, codec)
     }
     #[must_use]
     pub fn parser_fail(msg: alloc::string::String, codec: Codec) -> Self {
-        Self::from_kind(Kind::Parser { msg }, codec)
+        DecodeError {
+            kind: Box::new(DecodeErrorKind::Parser { msg }),
+            codec,
+            backtrace: None,
+        }
     }
 
     #[must_use]
     pub fn required_extension_not_present(tag: crate::types::Tag, codec: Codec) -> Self {
-        Self::from_kind(Kind::RequiredExtensionNotPresent { tag }, codec)
+        Self::from_kind(DecodeErrorKind::RequiredExtensionNotPresent { tag }, codec)
+    }
+    #[must_use]
+    pub fn extension_present_but_not_required(tag: crate::types::Tag, codec: Codec) -> Self {
+        Self::from_kind(
+            DecodeErrorKind::ExtensionPresentButNotRequired { tag },
+            codec,
+        )
     }
     #[must_use]
     pub fn enumeration_index_not_found(index: usize, extended_list: bool, codec: Codec) -> Self {
         Self::from_kind(
-            Kind::EnumerationIndexNotFound {
+            DecodeErrorKind::EnumerationIndexNotFound {
                 index,
                 extended_list,
             },
@@ -210,22 +236,25 @@ impl DecodeError {
     #[must_use]
     pub fn choice_index_exceeds_platform_width(needed: u32, present: u64, codec: Codec) -> Self {
         Self::from_kind(
-            Kind::ChoiceIndexExceedsPlatformWidth { needed, present },
+            DecodeErrorKind::ChoiceIndexExceedsPlatformWidth { needed, present },
             codec,
         )
     }
 
     #[must_use]
     pub fn choice_index_not_found(index: usize, variants: Variants, codec: Codec) -> Self {
-        Self::from_kind(Kind::ChoiceIndexNotFound { index, variants }, codec)
+        Self::from_kind(
+            DecodeErrorKind::ChoiceIndexNotFound { index, variants },
+            codec,
+        )
     }
     #[must_use]
     pub fn string_conversion_failed(tag: Tag, msg: alloc::string::String, codec: Codec) -> Self {
-        Self::from_kind(Kind::StringConversionFailed { tag, msg }, codec)
+        Self::from_kind(DecodeErrorKind::StringConversionFailed { tag, msg }, codec)
     }
     #[must_use]
     pub fn unexpected_extra_data(length: usize, codec: Codec) -> Self {
-        Self::from_kind(Kind::UnexpectedExtraData { length }, codec)
+        Self::from_kind(DecodeErrorKind::UnexpectedExtraData { length }, codec)
     }
 
     pub fn assert_length(
@@ -237,7 +266,7 @@ impl DecodeError {
             Ok(())
         } else {
             Err(DecodeError::from_kind(
-                Kind::MismatchedLength { expected, actual },
+                DecodeErrorKind::MismatchedLength { expected, actual },
                 codec,
             ))
         }
@@ -254,11 +283,11 @@ impl DecodeError {
         DecodeError::parser_fail(msg, codec)
     }
     #[must_use]
-    pub fn from_kind(kind: Kind, codec: Codec) -> Self {
+    pub fn from_kind(kind: DecodeErrorKind, codec: Codec) -> Self {
         Self {
-            kind,
+            kind: Box::new(kind),
             codec,
-            backtrace: Backtrace::generate(),
+            backtrace: Some(Backtrace::generate()),
         }
     }
     #[must_use]
@@ -271,9 +300,9 @@ impl DecodeError {
             CodecDecodeError::Aper(_) => crate::Codec::Aper,
         };
         Self {
-            kind: Kind::CodecSpecific { inner },
+            kind: Box::new(DecodeErrorKind::CodecSpecific { inner }),
             codec,
-            backtrace: Backtrace::generate(),
+            backtrace: Some(Backtrace::generate()),
         }
     }
 }
@@ -283,7 +312,7 @@ impl DecodeError {
 #[snafu(visibility(pub))]
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum Kind {
+pub enum DecodeErrorKind {
     #[snafu(display("Alphabet constraint not satisfied {}", reason))]
     AlphabetConstraintNotSatisfied { reason: PermittedAlphabetError },
     #[snafu(display("Wrapped codec-specific decode error"))]
@@ -329,11 +358,11 @@ pub enum Kind {
         /// The maximum length.
         length: num_bigint::BigUint,
     },
-    #[snafu(display("Error when decoding field `{}`: {}", name, msg))]
+    #[snafu(display("Error when decoding field `{}`: {}", name, nested))]
     FieldError {
         /// The field's name.
         name: &'static str,
-        msg: alloc::string::String,
+        nested: Box<DecodeError>,
     },
     /// Input is provided as BIT slice for nom in UPER/APER.
     /// On BER/CER/DER it is as BYTE slice.
@@ -402,6 +431,8 @@ pub enum Kind {
     },
     #[snafu(display("Extension with class `{}` and tag `{}` required, but not present", tag.class, tag.value))]
     RequiredExtensionNotPresent { tag: crate::types::Tag },
+    #[snafu(display("Extension {} present but but not required", tag.class))]
+    ExtensionPresentButNotRequired { tag: crate::types::Tag },
     #[snafu(display("Error in Parser: {}", msg))]
     Parser {
         /// The error's message.
@@ -488,7 +519,13 @@ impl BerDecodeErrorKind {
         if expected == actual {
             Ok(())
         } else {
-            Err(Self::MismatchedTag { expected, actual }.into())
+            Err(DecodeError {
+                kind: Box::new(DecodeErrorKind::CodecSpecific {
+                    inner: CodecDecodeError::Ber(Self::MismatchedTag { expected, actual }),
+                }),
+                codec: Codec::Ber,
+                backtrace: None,
+            })
         }
     }
 }
@@ -525,44 +562,47 @@ pub enum AperDecodeErrorKind {}
 impl crate::de::Error for DecodeError {
     fn custom<D: core::fmt::Display>(msg: D, codec: Codec) -> Self {
         Self::from_kind(
-            Kind::Custom {
+            DecodeErrorKind::Custom {
                 msg: msg.to_string(),
             },
             codec,
         )
     }
-
     fn incomplete(needed: nom::Needed, codec: Codec) -> Self {
-        Self::from_kind(Kind::Incomplete { needed }, codec)
+        DecodeError {
+            kind: Box::new(DecodeErrorKind::Incomplete { needed }),
+            codec,
+            backtrace: None,
+        }
     }
 
     fn exceeds_max_length(length: num_bigint::BigUint, codec: Codec) -> Self {
-        Self::from_kind(Kind::ExceedsMaxLength { length }, codec)
+        Self::from_kind(DecodeErrorKind::ExceedsMaxLength { length }, codec)
     }
 
     fn missing_field(name: &'static str, codec: Codec) -> Self {
-        Self::from_kind(Kind::MissingField { name }, codec)
+        Self::from_kind(DecodeErrorKind::MissingField { name }, codec)
     }
 
     fn no_valid_choice(name: &'static str, codec: Codec) -> Self {
-        Self::from_kind(Kind::NoValidChoice { name }, codec)
+        Self::from_kind(DecodeErrorKind::NoValidChoice { name }, codec)
     }
 
-    fn field_error<D: core::fmt::Display>(name: &'static str, error: D, codec: Codec) -> Self {
+    fn field_error(name: &'static str, nested: DecodeError, codec: Codec) -> Self {
         Self::from_kind(
-            Kind::FieldError {
+            DecodeErrorKind::FieldError {
                 name,
-                msg: error.to_string(),
+                nested: Box::new(nested),
             },
             codec,
         )
     }
 
     fn duplicate_field(name: &'static str, codec: Codec) -> Self {
-        Self::from_kind(Kind::DuplicateField { name }, codec)
+        Self::from_kind(DecodeErrorKind::DuplicateField { name }, codec)
     }
     fn unknown_field(index: usize, tag: Tag, codec: Codec) -> Self {
-        Self::from_kind(Kind::UnknownField { index, tag }, codec)
+        Self::from_kind(DecodeErrorKind::UnknownField { index, tag }, codec)
     }
 }
 #[cfg(test)]
@@ -577,23 +617,22 @@ mod tests {
         ];
         let result = crate::ber::decode::<UtcTime>(&data);
         match result {
-            Err(DecodeError {
-                kind:
-                    DecodeErrorKind::CodecSpecific {
-                        inner:
-                            crate::error::CodecDecodeError::Ber(
-                                crate::error::BerDecodeErrorKind::InvalidDate { msg },
-                            ),
-                        ..
-                    },
-                ..
-            }) => {
-                assert_eq!(msg, "230122130000-050Z");
+            Err(DecodeError { kind, .. }) => {
+                if let DecodeErrorKind::CodecSpecific {
+                    inner:
+                        crate::error::CodecDecodeError::Ber(
+                            crate::error::BerDecodeErrorKind::InvalidDate { msg },
+                        ),
+                    ..
+                } = *kind
+                {
+                    assert_eq!(msg, "230122130000-050Z");
+                } else {
+                    // Handle other kinds of errors
+                    panic!("Unexpected error kind: {kind}");
+                }
             }
             Ok(_) => panic!("Expected error"),
-            _ => {
-                panic!("Unexpected error")
-            }
         }
     }
     #[test]
@@ -615,14 +654,13 @@ mod tests {
             Ok(_) => {
                 panic!("Unexpected OK!");
             }
-            Err(DecodeError {
-                kind: DecodeErrorKind::ChoiceIndexNotFound { index, .. },
-                ..
-            }) => {
-                assert_eq!(index, 3);
-            }
-            Err(e) => {
-                panic!("Unexpected error kind: {e}");
+            Err(DecodeError { kind, .. }) => {
+                if let DecodeErrorKind::ChoiceIndexNotFound { index, .. } = *kind {
+                    assert_eq!(index, 3);
+                } else {
+                    // Handle other kinds of errors
+                    panic!("Unexpected error kind: {kind}");
+                }
             }
         }
     }

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -1,7 +1,7 @@
 use crate::types::constraints::{Bounded, Size};
 use snafu::{Backtrace, GenerateImplicitData, Snafu};
 
-use alloc::string::ToString;
+use alloc::{boxed::Box, string::ToString};
 
 /// Variants for every codec-specific `EncodeError` kind.
 #[derive(Debug)]
@@ -69,8 +69,8 @@ impl From<CodecEncodeError> for EncodeError {
 ///             dbg!(succ);
 ///         }
 ///         Err(e) => {
-///             // e is EncodeError
-///             match e.kind {
+///             // e is EncodeError, Kind is boxed
+///             match *e.kind {
 ///                 EncodeErrorKind::AlphabetConstraintNotSatisfied {
 ///                     reason: PermittedAlphabetError::CharacterNotFound {character },
 ///                 } => {
@@ -94,14 +94,21 @@ impl From<CodecEncodeError> for EncodeError {
 /// }
 /// ```
 ///
-#[derive(Snafu, Debug)]
-#[snafu(visibility(pub))]
-#[snafu(display("Error Kind: {}\nBacktrace:\n{}", kind, backtrace))]
+#[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct EncodeError {
-    pub kind: EncodeErrorKind,
+    pub kind: Box<EncodeErrorKind>,
     pub codec: crate::Codec,
     pub backtrace: Backtrace,
+}
+impl core::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "Error Kind: {}", self.kind)?;
+        writeln!(f, "Codec: {}", self.kind)?;
+        write!(f, "\nBacktrace:\n{}", self.backtrace)?;
+
+        Ok(())
+    }
 }
 impl EncodeError {
     #[must_use]
@@ -110,17 +117,17 @@ impl EncodeError {
         codec: crate::Codec,
     ) -> Self {
         Self {
-            kind: EncodeErrorKind::AlphabetConstraintNotSatisfied { reason },
+            kind: Box::new(EncodeErrorKind::AlphabetConstraintNotSatisfied { reason }),
             codec,
             backtrace: Backtrace::generate(),
         }
     }
     pub fn check_length(length: usize, expected: &Size, codec: crate::Codec) -> Result<(), Self> {
         expected.contains_or_else(&length, || Self {
-            kind: EncodeErrorKind::InvalidLength {
+            kind: Box::new(EncodeErrorKind::InvalidLength {
                 length,
                 expected: (**expected),
-            },
+            }),
             codec,
             backtrace: Backtrace::generate(),
         })
@@ -128,32 +135,20 @@ impl EncodeError {
     /// An error for failed conversion from `BitInt` or `BigUint` to primitive integer types
     #[must_use]
     pub fn integer_type_conversion_failed(msg: alloc::string::String, codec: crate::Codec) -> Self {
-        Self {
-            kind: EncodeErrorKind::IntegerTypeConversionFailed { msg },
-            codec,
-            backtrace: Backtrace::generate(),
-        }
+        Self::from_kind(EncodeErrorKind::IntegerTypeConversionFailed { msg }, codec)
     }
     #[must_use]
     pub fn opaque_conversion_failed(msg: alloc::string::String, codec: crate::Codec) -> Self {
-        Self {
-            kind: EncodeErrorKind::OpaqueConversionFailed { msg },
-            codec,
-            backtrace: Backtrace::generate(),
-        }
+        Self::from_kind(EncodeErrorKind::OpaqueConversionFailed { msg }, codec)
     }
     #[must_use]
     pub fn variant_not_in_choice(codec: crate::Codec) -> Self {
-        Self {
-            kind: EncodeErrorKind::VariantNotInChoice,
-            codec,
-            backtrace: Backtrace::generate(),
-        }
+        Self::from_kind(EncodeErrorKind::VariantNotInChoice, codec)
     }
     #[must_use]
     pub fn from_kind(kind: EncodeErrorKind, codec: crate::Codec) -> Self {
         Self {
-            kind,
+            kind: Box::new(kind),
             codec,
             backtrace: Backtrace::generate(),
         }
@@ -168,7 +163,7 @@ impl EncodeError {
             CodecEncodeError::Aper(_) => crate::Codec::Aper,
         };
         Self {
-            kind: EncodeErrorKind::CodecSpecific { inner },
+            kind: Box::new(EncodeErrorKind::CodecSpecific { inner }),
             codec,
             backtrace: Backtrace::generate(),
         }
@@ -253,9 +248,9 @@ pub enum AperEncodeErrorKind {}
 impl crate::enc::Error for EncodeError {
     fn custom<D: core::fmt::Display>(msg: D, codec: crate::Codec) -> Self {
         Self {
-            kind: EncodeErrorKind::Custom {
+            kind: Box::new(EncodeErrorKind::Custom {
                 msg: msg.to_string(),
-            },
+            }),
             codec,
             backtrace: Backtrace::generate(),
         }
@@ -284,17 +279,15 @@ mod tests {
         let result = enc.encode_object_identifier(Tag::OBJECT_IDENTIFIER, &oid);
         assert!(result.is_err());
         match result {
-            Err(EncodeError {
-                kind:
-                    EncodeErrorKind::CodecSpecific {
-                        inner:
-                            CodecEncodeError::Ber(BerEncodeErrorKind::InvalidObjectIdentifier {
-                                ..
-                            }),
-                    },
-                ..
-            }) => {}
-            _ => panic!("Expected invalid object identifier error of specific type!"),
+            Err(e) => match *e.kind {
+                EncodeErrorKind::CodecSpecific {
+                    inner: CodecEncodeError::Ber(BerEncodeErrorKind::InvalidObjectIdentifier { .. }),
+                } => {}
+                _ => {
+                    panic!("Expected invalid object identifier error of specific type!");
+                }
+            },
+            _ => panic!("Unexpected OK!"),
         }
         // Debug output should look something like this:
         // dbg!(result.err());
@@ -330,7 +323,7 @@ mod tests {
             Ok(_) => {}
             Err(e) => {
                 // EncodeError
-                match e.kind {
+                match *e.kind {
                     EncodeErrorKind::AlphabetConstraintNotSatisfied {
                         reason: PermittedAlphabetError::CharacterNotFound { .. },
                     } => {}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -14,7 +14,7 @@ pub mod strings {
     };
 }
 
-pub use decode::Kind as DecodeErrorKind;
+pub use decode::DecodeErrorKind;
 pub use decode::{BerDecodeErrorKind, CodecDecodeError, DecodeError, DerDecodeErrorKind};
 pub use encode::EncodeErrorKind;
 pub use encode::{BerEncodeErrorKind, CodecEncodeError, EncodeError};


### PR DESCRIPTION
Boxed `Kind` type for error variants.
Also some other error improvements.

~~Parser errors from `Incomplete` and `MismatchedTag` does not include backtrace anymore.
Should restore the performance.~~ 