### PR TITLE
Add `Option<T::EXTENDED_VARIANTS>` for Choice, clippy cleanup

### DIFF
--- a/src/jer/de.rs
+++ b/src/jer/de.rs
@@ -528,8 +528,10 @@ impl Decoder {
                     .map(|(i, _)| (i, v))
             })
             .map_or(Tag::EOC, |(i, v)| {
-                match variants::Variants::from_slice(&[D::VARIANTS, D::EXTENDED_VARIANTS].concat())
-                    .get(i)
+                match variants::Variants::from_slice(
+                    &[D::VARIANTS, D::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
+                )
+                .get(i)
                 {
                     Some(t) => {
                         self.stack.push(v.clone());

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -368,8 +368,9 @@ impl crate::Encoder for Encoder {
         identifier: &'static str,
         encode_fn: impl FnOnce(&mut Self) -> Result<crate::Tag, Self::Error>,
     ) -> Result<Self::Ok, Self::Error> {
-        let variants =
-            variants::Variants::from_slice(&[E::VARIANTS, E::EXTENDED_VARIANTS].concat());
+        let variants = variants::Variants::from_slice(
+            &[E::VARIANTS, E::EXTENDED_VARIANTS.unwrap_or(&[])].concat(),
+        );
         if variants.is_empty() {
             self.update_root_or_constructed(JsonValue::Object(Object::new()))
         } else {

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -957,7 +957,7 @@ impl<'input> crate::Decoder for Decoder<'input> {
     {
         let is_extensible = self.parse_extensible_bit(&constraints)?;
         let variants = crate::types::variants::Variants::from_static(if is_extensible {
-            D::EXTENDED_VARIANTS
+            D::EXTENDED_VARIANTS.unwrap_or(&[])
         } else {
             D::VARIANTS
         });

--- a/src/per/enc.rs
+++ b/src/per/enc.rs
@@ -1079,7 +1079,7 @@ impl crate::Encoder for Encoder {
         let mut buffer = BitString::new();
         let mut choice_encoder = Self::new(self.options.without_set_encoding());
         // Extensibility must be noted for byte alignment
-        if E::CONSTRAINTS.extensible() && self.options.aligned {
+        if E::EXTENDED_VARIANTS.is_some() && self.options.aligned {
             choice_encoder.parent_output_length = Some(1);
         }
 
@@ -1090,7 +1090,7 @@ impl crate::Encoder for Encoder {
         let variants = crate::types::variants::Variants::from_static(if is_root_extension {
             E::VARIANTS
         } else {
-            E::EXTENDED_VARIANTS
+            E::EXTENDED_VARIANTS.unwrap_or(&[])
         });
 
         let index = variants

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,7 +76,7 @@ pub trait Choice: Sized {
     /// Variants contained in the "root component list".
     const VARIANTS: &'static [TagTree];
     /// Variants contained in the list of extensions.
-    const EXTENDED_VARIANTS: &'static [TagTree] = &[];
+    const EXTENDED_VARIANTS: Option<&'static [TagTree]> = None;
     /// Variant identifiers for text-based encoding rules
     const IDENTIFIERS: &'static [&'static str];
 }


### PR DESCRIPTION
I double checked `Option<T::EXTENDED_VARIANTS>` for Choice, and it was actually missing. Seems like it was not too bad to add.