### PR TITLE
Fix PER ObjectIdentifier, correct Alignment for Choice index encoding

### DIFF
--- a/src/ber/enc.rs
+++ b/src/ber/enc.rs
@@ -357,6 +357,7 @@ impl crate::Encoder for Encoder {
     fn encode_choice<E: Encode>(
         &mut self,
         _: Constraints,
+        _t: Tag,
         _i: &str,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
     ) -> Result<Self::Ok, Self::Error> {

--- a/src/enc.rs
+++ b/src/enc.rs
@@ -322,6 +322,7 @@ pub trait Encoder {
     fn encode_choice<E: Encode + crate::types::Choice>(
         &mut self,
         constraints: Constraints,
+        tag: Tag,
         identifier: &'static str,
         encode_fn: impl FnOnce(&mut Self) -> Result<Tag, Self::Error>,
     ) -> Result<Self::Ok, Self::Error>;

--- a/src/jer/enc.rs
+++ b/src/jer/enc.rs
@@ -365,6 +365,7 @@ impl crate::Encoder for Encoder {
     fn encode_choice<E: crate::Encode + crate::types::Choice>(
         &mut self,
         _c: crate::types::Constraints,
+        _t: crate::types::Tag,
         identifier: &'static str,
         encode_fn: impl FnOnce(&mut Self) -> Result<crate::Tag, Self::Error>,
     ) -> Result<Self::Ok, Self::Error> {

--- a/src/per/de.rs
+++ b/src/per/de.rs
@@ -678,7 +678,8 @@ impl<'input> crate::Decoder for Decoder<'input> {
 
     fn decode_object_identifier(&mut self, _: Tag) -> Result<crate::types::ObjectIdentifier> {
         let octets = self.decode_octets()?.into_vec();
-        crate::ber::decode(&octets)
+        let decoder = crate::ber::de::Decoder::new(&octets, crate::ber::de::DecoderOptions::ber());
+        decoder.decode_object_identifier_from_bytes(&octets)
     }
 
     fn decode_bit_string(&mut self, _: Tag, constraints: Constraints) -> Result<types::BitString> {

--- a/src/uper.rs
+++ b/src/uper.rs
@@ -977,4 +977,34 @@ mod tests {
             &[96, 8, 5, 52]
         );
     }
+    #[test]
+    fn test_object_identifier() {
+        round_trip!(
+            uper,
+            ObjectIdentifier,
+            ObjectIdentifier::new(vec![1, 2]).unwrap(),
+            &[0x01u8, 0x2a]
+        );
+        round_trip!(
+            uper,
+            ObjectIdentifier,
+            ObjectIdentifier::new(vec![1, 2, 3321]).unwrap(),
+            &[0x03u8, 0x2a, 0x99, 0x79]
+        );
+        #[derive(AsnType, Debug, Decode, Encode, PartialEq)]
+        #[rasn(crate_root = "crate")]
+        struct B {
+            a: bool,
+            b: ObjectIdentifier,
+        }
+        round_trip!(
+            uper,
+            B,
+            B {
+                a: true,
+                b: ObjectIdentifier::new(vec![1, 2]).unwrap()
+            },
+            &[0x80, 0x95, 0x00]
+        );
+    }
 }


### PR DESCRIPTION
Fixes #201 

PER implementation for ObjectIdentifier is now the same than in asn1tools PER and in OER here, it should include only content objects of DER encoding and not the tag or length. 

There are also some wild macros to get tag information for choice before encoding. 