### PR TITLE
Fix issue with decoding of BasicOcspResponse.

### DIFF
--- a/standards/ocsp/src/lib.rs
+++ b/standards/ocsp/src/lib.rs
@@ -142,7 +142,7 @@ pub struct BasicOcspResponse {
 /// The body of [BasicOcspResponse].
 #[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResponseData {
-    #[rasn(tag(explicit(0), default))]
+    #[rasn(tag(explicit(0)), default)]
     pub version: Version,
     pub responder_id: ResponderId,
     pub produced_at: GeneralizedTime,


### PR DESCRIPTION
Fixes an issue decoding a `BasicOcspResponse`, looks to be because the `version` field's `default` attribute was not being picked up.

Not sure if this was a typo or if there is a compiler that generates this and the issue is from there.