### PR TITLE
Make backtraces as feature, enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ chrono = { version = "0.4.27", default-features = false, features = ["alloc"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 
 [features]
-default = ["macros"]
+default = ["macros" ]
 macros = ["rasn-derive"]
+backtraces = []
 
 [[bench]]
 name = "criterion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4.27", default-features = false, features = ["alloc"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 
 [features]
-default = ["macros" ]
+default = ["macros", "backtraces"]
 macros = ["rasn-derive"]
 backtraces = []
 

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -2,7 +2,9 @@ use super::strings::PermittedAlphabetError;
 use alloc::{boxed::Box, string::ToString};
 
 use jzon::JsonValue;
-use snafu::{Backtrace, GenerateImplicitData, Snafu};
+use snafu::Snafu;
+#[cfg(feature = "backtraces")]
+use snafu::{Backtrace, GenerateImplicitData};
 
 use crate::de::Error;
 use crate::types::variants::Variants;
@@ -68,6 +70,7 @@ impl From<CodecDecodeError> for DecodeError {
 ///
 /// fn main() {
 ///     // Hello, World! in decimal bytes with trailing zeros
+///     // Below sample requires that `backtraces` feature is enabled
 ///     let hello_data = vec![
 ///         13, 145, 151, 102, 205, 235, 16, 119, 223, 203, 102, 68, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ///         0,
@@ -100,12 +103,14 @@ impl From<CodecDecodeError> for DecodeError {
 ///                                
 ///                             }
 ///                             _ => {
+///                                 #[cfg(feature = "backtraces")]
 ///                                 println!("Backtrace:\n{:?}", e.backtrace);
 ///                                 panic!("Unexpected error! {e:?}");
 ///                             }
 ///                         }
 ///                     }
 ///                     k => {
+///                         #[cfg(feature = "backtraces")]
 ///                         println!("Backtrace:\n{:?}", e.backtrace);
 ///                         panic!("Unexpected error! {k:?}");
 ///                     }
@@ -127,12 +132,14 @@ impl From<CodecDecodeError> for DecodeError {
 pub struct DecodeError {
     pub kind: Box<DecodeErrorKind>,
     pub codec: Codec,
+    #[cfg(feature = "backtraces")]
     pub backtrace: Backtrace,
 }
 impl core::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "Error Kind: {}", self.kind)?;
         writeln!(f, "Codec: {}", self.kind)?;
+        #[cfg(feature = "backtraces")]
         write!(f, "\nBacktrace:\n{}", self.backtrace)?;
         Ok(())
     }
@@ -284,6 +291,7 @@ impl DecodeError {
         Self {
             kind: Box::new(kind),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         }
     }
@@ -300,6 +308,7 @@ impl DecodeError {
         Self {
             kind: Box::new(DecodeErrorKind::CodecSpecific { inner }),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         }
     }

--- a/src/error/encode.rs
+++ b/src/error/encode.rs
@@ -1,5 +1,7 @@
 use crate::types::constraints::{Bounded, Size};
-use snafu::{Backtrace, GenerateImplicitData, Snafu};
+use snafu::Snafu;
+#[cfg(feature = "backtraces")]
+use snafu::{Backtrace, GenerateImplicitData};
 
 use alloc::{boxed::Box, string::ToString};
 
@@ -62,6 +64,7 @@ impl From<CodecEncodeError> for EncodeError {
 /// );
 ///
 /// fn main() {
+///     // Below sample requires that `backtraces` feature is enabled
 ///
 ///     let constrained_str = MyConstrainedString(VisibleString::try_from("abcD").unwrap());
 ///     let encoded = Codec::Uper.encode_to_binary(&constrained_str);
@@ -79,6 +82,7 @@ impl From<CodecEncodeError> for EncodeError {
 ///                     println!("Codec: {}", e.codec);
 ///                     println!("Character {} not found from the permitted list.",
 ///                              char::from_u32(character).unwrap());
+///                     #[cfg(feature = "backtraces")]
 ///                     println!("Backtrace:\n{}", e.backtrace);
 ///                 }
 ///                 _ => {
@@ -101,12 +105,14 @@ impl From<CodecEncodeError> for EncodeError {
 pub struct EncodeError {
     pub kind: Box<EncodeErrorKind>,
     pub codec: crate::Codec,
+    #[cfg(feature = "backtraces")]
     pub backtrace: Backtrace,
 }
 impl core::fmt::Display for EncodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "Error Kind: {}", self.kind)?;
         writeln!(f, "Codec: {}", self.kind)?;
+        #[cfg(feature = "backtraces")]
         write!(f, "\nBacktrace:\n{}", self.backtrace)?;
 
         Ok(())
@@ -121,6 +127,7 @@ impl EncodeError {
         Self {
             kind: Box::new(EncodeErrorKind::AlphabetConstraintNotSatisfied { reason }),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         }
     }
@@ -131,6 +138,7 @@ impl EncodeError {
                 expected: (**expected),
             }),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         })
     }
@@ -152,6 +160,7 @@ impl EncodeError {
         Self {
             kind: Box::new(kind),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         }
     }
@@ -168,6 +177,7 @@ impl EncodeError {
         Self {
             kind: Box::new(EncodeErrorKind::CodecSpecific { inner }),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         }
     }
@@ -283,6 +293,7 @@ impl crate::enc::Error for EncodeError {
                 msg: msg.to_string(),
             }),
             codec,
+            #[cfg(feature = "backtraces")]
             backtrace: Backtrace::generate(),
         }
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,5 +1,6 @@
 //! Error module includes all encode and decode errors among all codecs.
 //! Encoding can result to `EncodeError` and decoding can result to `DecodeError`.
+//! Backtraces are enabled by default with `backtraces` feature.
 //! See submodules for other error types.
 #![allow(clippy::module_name_repetitions)]
 mod decode;


### PR DESCRIPTION
This PR makes backtraces optional, while enabled by default.

Sometimes it can be very desireable to disable them totally.

E.g. when fuzzing, with backtraces you get unstable 100-5000 execs per second, but without them it is 50k execes per second (from OER and with AFL).

There might be some other scenarios where performance gets priority over exact error sources.